### PR TITLE
fix: support invited by in waitlist invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Waitlist::invite($entryId);      // By ID
 Waitlist::reject($entry);
 Waitlist::reject($entryId);
 
+// Pass options through to the underlying invitation
+// $entry is a WaitlistEntry, e.g. from Waitlist::getByEmail() or getPending()
+$entry = Waitlist::for('beta')->getByEmail('john@example.com');
+
+Waitlist::invite($entry, [
+    'invited_by' => $admin,        // Model or int; falls back to auth()->user()
+    'role' => 'beta-tester',
+    'metadata' => ['cohort' => 'wave-3'],
+    'expires_at' => now()->addDays(14),
+]);
+
 // Query entries
 $pending = Waitlist::for('beta')->getPending();
 $invited = Waitlist::for('beta')->getInvited();
@@ -513,7 +524,7 @@ Waitlist::getDefault(): Waitlist
 Waitlist::add(string $name, string $email, array $metadata = []): WaitlistEntry
 
 // Managing status
-Waitlist::invite(int|WaitlistEntry $entry): WaitlistEntry
+Waitlist::invite(int|WaitlistEntry $entry, array $options = []): WaitlistEntry
 Waitlist::reject(int|WaitlistEntry $entry): WaitlistEntry
 
 // Email verification

--- a/src/WaitlistService.php
+++ b/src/WaitlistService.php
@@ -104,7 +104,9 @@ final class WaitlistService
             $this->resolveInvitationMetadata($entry),
             $options,
         );
-        $inviteOptions['invited_by'] ??= auth()->user();
+        if (! array_key_exists('invited_by', $inviteOptions)) {
+            $inviteOptions['invited_by'] = auth()->user();
+        }
 
         $invitation = InviteOnly::invite($entry->email, $invitable, $inviteOptions);
 

--- a/src/WaitlistService.php
+++ b/src/WaitlistService.php
@@ -86,9 +86,11 @@ final class WaitlistService
     }
 
     /**
+     * @param  array{role?: string, metadata?: array<string, mixed>, expires_at?: \Illuminate\Support\Carbon, invited_by?: Model|int}  $options
+     *
      * @throws UnverifiedEntryException
      */
-    public function invite(int|WaitlistEntry $entry): WaitlistEntry
+    public function invite(int|WaitlistEntry $entry, array $options = []): WaitlistEntry
     {
         $entry = $this->resolveEntry($entry);
 
@@ -98,9 +100,13 @@ final class WaitlistService
 
         // Create invitation via laravel-invite-only
         $invitable = $this->resolveInvitable($entry);
-        $metadata = $this->resolveInvitationMetadata($entry);
+        $inviteOptions = array_merge(
+            $this->resolveInvitationMetadata($entry),
+            $options,
+        );
+        $inviteOptions['invited_by'] ??= auth()->user();
 
-        $invitation = InviteOnly::invite($entry->email, $invitable, $metadata);
+        $invitation = InviteOnly::invite($entry->email, $invitable, $inviteOptions);
 
         $entry->update(['invitation_id' => $invitation->id]);
         $entry->markAsInvited();

--- a/tests/Feature/WaitlistTest.php
+++ b/tests/Feature/WaitlistTest.php
@@ -178,6 +178,26 @@ test('invited_by is null when no user is authenticated and none provided', funct
     expect($entry->invitation->invited_by)->toBeNull();
 });
 
+test('explicit invited_by null is respected even when a user is authenticated', function () {
+    Notification::fake();
+
+    $authed = new class extends Illuminate\Foundation\Auth\User
+    {
+        public function getKey(): int
+        {
+            return 99;
+        }
+    };
+    auth()->setUser($authed);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::invite($entry, ['invited_by' => null]);
+
+    $entry->refresh();
+
+    expect($entry->invitation->invited_by)->toBeNull();
+});
+
 test('can reject user from waitlist', function () {
     $entry = Waitlist::add('John Doe', 'john@example.com');
     Waitlist::reject($entry);

--- a/tests/Feature/WaitlistTest.php
+++ b/tests/Feature/WaitlistTest.php
@@ -136,6 +136,48 @@ test('can invite user by id', function () {
         ->and($entry->invitation_id)->not->toBeNull();
 });
 
+test('passes invited_by from options through to invitation', function () {
+    Notification::fake();
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::invite($entry, ['invited_by' => 42]);
+
+    $entry->refresh();
+
+    expect($entry->invitation->invited_by)->toBe(42);
+});
+
+test('falls back to authenticated user as invited_by', function () {
+    Notification::fake();
+
+    $inviter = new class extends Illuminate\Foundation\Auth\User
+    {
+        public function getKey(): int
+        {
+            return 7;
+        }
+    };
+    auth()->setUser($inviter);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::invite($entry);
+
+    $entry->refresh();
+
+    expect($entry->invitation->invited_by)->toBe(7);
+});
+
+test('invited_by is null when no user is authenticated and none provided', function () {
+    Notification::fake();
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::invite($entry);
+
+    $entry->refresh();
+
+    expect($entry->invitation->invited_by)->toBeNull();
+});
+
 test('can reject user from waitlist', function () {
     $entry = Waitlist::add('John Doe', 'john@example.com');
     Waitlist::reject($entry);


### PR DESCRIPTION
## Allow invited_by (and other options) to be passed through Waitlist::invite()                                                                                    
WaitlistService::invite() now accepts an optional array $options = [] second argument that's forwarded to InviteOnly::invite(). This unblocks setting invited_by (the field was always being written as null) and also exposes role, metadata, and expires_at to callers without changing existing call sites.                  
                                                                                                                                                                  
### Why                                                                                                                                                           
Inviting from the waitlist always resulted in invitations.invited_by = null, since the service had no parameter for it and never consulted auth(). The fix belongs in the package — every consumer benefits, and no app-side wrapper is needed.

### Behavior
- Caller-supplied options override config-derived defaults from resolveInvitationMetadata().                                                                    
- If invited_by is not provided, it falls back to auth()->user().
- If no user is authenticated and none is passed, invited_by stays null (prior behavior).                                                                       
- Backward compatible — Waitlist::invite($entry) still works unchanged.    