### PR TITLE
feat: list serve integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ implement your own controllers, views, and API endpoints.
 - **Status tracking** — Pending, invited, and rejected states
 - **Email verification** — Optional opt-in verification before inviting users
 - **Event-driven notifications** — Automatic invite + verification notifications, fully customizable
+- **Mailing list sync** — Push entries to Mailchimp or Kit (ConvertKit), or plug in a driver of your own
+- **Events** — Hook into every step of the lifecycle, from sign up to invite
 - **Metadata support** — Store custom data with each entry
 - **Invite-only integration** — Optional bridge into `offload-project/laravel-invite-only` for token-based flows
 - **Type-safe** — Full PHPStan compliance
@@ -36,6 +38,8 @@ implement your own controllers, views, and API endpoints.
     - [Custom Controller / Livewire](#custom-controller--livewire)
     - [Custom Notifications](#custom-notifications)
     - [Email Verification](#email-verification)
+    - [Mailing List Integration](#mailing-list-integration)
+    - [Events](#events)
 - [Configuration](#configuration)
 - [Database Schema](#database-schema)
 - [API Reference](#api-reference)
@@ -430,6 +434,141 @@ class CustomVerifyEmail extends Notification
 }
 ```
 
+### Mailing List Integration
+
+Sync entries into a newsletter service as they join. Mailchimp and Kit (ConvertKit) ship with the package, and you can
+register a driver for anything else.
+
+```dotenv
+WAITLIST_MAILING_LIST_ENABLED=true
+WAITLIST_MAILING_LIST_DRIVER=mailchimp
+
+MAILCHIMP_API_KEY=1234567890abcdef-us14
+```
+
+Then point a waitlist at a list — the id is whatever the provider calls it:
+
+```php
+use OffloadProject\Waitlist\Facades\Waitlist;
+
+Waitlist::for('beta')->connectMailingList('a1b2c3d4e5');          // a Mailchimp audience
+Waitlist::for('launch')->connectMailingList('7654321', 'kit');    // a Kit form, on a different driver
+```
+
+Each waitlist can sync into a different list, and into a different service. Waitlists that aren't connected fall back to
+the driver's `list_id` in the config, so a single-list setup needs no `connectMailingList()` call at all.
+
+From there, entries subscribe themselves — and the timing follows your verification setting:
+
+| `verification.enabled` | The entry is subscribed             |
+|------------------------|-------------------------------------|
+| `false`                | as soon as they join the waitlist   |
+| `true`                 | once they have confirmed their email |
+
+That way an unconfirmed address never reaches your newsletter. Syncing runs in a queued job, so sign ups never wait on
+the provider's API.
+
+#### Drivers
+
+| Driver      | The list id is                                       | Notes                                                                     |
+|-------------|------------------------------------------------------|---------------------------------------------------------------------------|
+| `mailchimp` | an audience id                                       | Contacts are upserted, so an existing unsubscribe is never overridden       |
+| `kit`       | a form id, or a tag id with `list_type` set to `tag` | Kit unsubscribes are account-wide; double opt-in follows the form's setting |
+| `log`       | anything                                             | Writes what would have been sent to the log — handy for local work          |
+| `array`     | anything                                             | In-memory, used by `MailingList::fake()` in tests                           |
+
+#### Backfilling existing entries
+
+```bash
+php artisan waitlist:sync-mailing-list                # the default waitlist
+php artisan waitlist:sync-mailing-list beta           # one waitlist
+php artisan waitlist:sync-mailing-list --all          # every waitlist
+php artisan waitlist:sync-mailing-list --all --force  # include entries already synced
+```
+
+Or from code, which returns the number of entries queued:
+
+```php
+Waitlist::for('beta')->syncMailingList();
+```
+
+#### Syncing by hand
+
+Set `mailing_list.auto_subscribe` to `false` and drive it yourself:
+
+```php
+use OffloadProject\Waitlist\Facades\MailingList;
+
+Waitlist::subscribeToMailingList($entry);
+Waitlist::unsubscribeFromMailingList($entry);
+
+MailingList::tagEntry($entry, ['beta-cohort']);
+```
+
+#### Custom fields
+
+Map entry data onto Mailchimp merge fields or Kit custom fields:
+
+```php
+// config/waitlist.php
+'attributes' => fn (WaitlistEntry $entry) => [
+    'SOURCE' => $entry->metadata['referral_source'] ?? 'direct',
+],
+```
+
+Note that a config file holding a closure cannot be cached with `php artisan config:cache`.
+
+#### Adding a driver
+
+Implement `OffloadProject\Waitlist\Contracts\MailingListDriver` and register it from a service provider:
+
+```php
+MailingList::extend('brevo', fn (array $config) => new BrevoDriver($config['key']));
+```
+
+`$config` is whatever sits under `waitlist.mailing_list.drivers.brevo`.
+
+#### Testing
+
+`MailingList::fake()` swaps in the in-memory driver and runs syncs inline:
+
+```php
+$mailingList = MailingList::fake();
+
+Waitlist::add('John Doe', 'john@example.com');
+
+expect($mailingList->hasSubscriber('john@example.com'))->toBeTrue();
+```
+
+### Events
+
+Every step of the lifecycle fires an event, so you can hook in without wrapping the facade:
+
+| Event                       | Fired when                                          | Payload                        |
+|-----------------------------|-----------------------------------------------------|--------------------------------|
+| `WaitlistCreated`           | a waitlist is created                               | `$waitlist`                    |
+| `WaitlistEntryAdded`        | someone joins a waitlist                            | `$entry`                       |
+| `WaitlistEntryVerified`     | an entry confirms their email                       | `$entry`                       |
+| `WaitlistEntryInvited`      | an entry is invited                                 | `$entry`                       |
+| `WaitlistEntryRejected`     | an entry is rejected                                | `$entry`                       |
+| `WaitlistEntrySubscribed`   | an entry reaches the mailing list                   | `$entry`, `$subscriber`, `$driver` |
+| `WaitlistEntryUnsubscribed` | an entry is removed from the mailing list           | `$entry`, `$driver`            |
+| `MailingListSyncFailed`     | a sync could not be completed                       | `$entry`, `$driver`, `$exception` |
+
+They all live in `OffloadProject\Waitlist\Events`. Tagging people in your newsletter as they get invited, for example:
+
+```php
+use Illuminate\Support\Facades\Event;
+use OffloadProject\Waitlist\Events\WaitlistEntryInvited;
+use OffloadProject\Waitlist\Facades\MailingList;
+
+Event::listen(function (WaitlistEntryInvited $event) {
+    MailingList::tagEntry($event->entry, ['invited']);
+});
+```
+
+The lifecycle events fire from the model, so they also cover `$entry->markAsInvited()` and friends — not just the facade.
+
 ## Configuration
 
 ```php
@@ -458,6 +597,35 @@ return [
         'enabled' => true,  // Enable package routes
         'prefix' => 'waitlist',  // URL prefix
         'middleware' => ['web'],  // Middleware
+    ],
+
+    // Mailing list integration
+    'mailing_list' => [
+        'enabled' => false,  // Turn syncing on
+        'default' => 'log',  // mailchimp, kit, log, array — or your own
+        'auto_subscribe' => true,  // Subscribe entries automatically
+        'double_optin' => false,  // Mailchimp only; Kit follows the form's setting
+        'tags' => [],  // Applied to every subscriber the package creates
+        'attributes' => null,  // Closure mapping an entry to provider fields
+        'queue' => [
+            'enabled' => true,  // Sync in a queued job
+            'connection' => null,
+            'queue' => null,
+        ],
+        'timeout' => 10,  // HTTP timeout in seconds
+        'retries' => 2,  // Retries per request
+        'drivers' => [
+            'mailchimp' => [
+                'key' => env('MAILCHIMP_API_KEY'),
+                'server' => env('MAILCHIMP_SERVER_PREFIX'),  // Derived from the key when null
+                'list_id' => env('MAILCHIMP_LIST_ID'),  // Fallback audience
+            ],
+            'kit' => [
+                'key' => env('KIT_API_KEY'),
+                'list_type' => env('KIT_LIST_TYPE', 'form'),  // form or tag
+                'list_id' => env('KIT_FORM_ID'),
+            ],
+        ],
     ],
 ];
 ```
@@ -488,9 +656,12 @@ Indexed fields: `slug`, `is_active`
 - `verification_token` — Token for email verification (nullable)
 - `verified_at` — Timestamp when email was verified (nullable)
 - `invitation_id` — Optional FK to `offload-project/laravel-invite-only` invitation (nullable)
+- `mailing_list_driver` — The driver the entry was synced with (nullable)
+- `mailing_list_subscriber_id` — The subscriber's id on the mailing list service (nullable)
+- `mailing_list_synced_at` — Timestamp of the last successful sync (nullable)
 - `created_at` / `updated_at` — Laravel timestamps
 
-Indexed fields: `status`, `created_at`, `verification_token`
+Indexed fields: `status`, `created_at`, `verification_token`, `mailing_list_synced_at`
 Unique constraint: `['waitlist_id', 'email']` (same email can join multiple waitlists)
 
 ## API Reference
@@ -528,6 +699,37 @@ Waitlist::exists(string $email): bool
 Waitlist::count(): int
 Waitlist::countPending(): int
 Waitlist::countInvited(): int
+
+// Mailing list (uses current waitlist context or default)
+Waitlist::connectMailingList(string $listId, ?string $driver = null): Waitlist
+Waitlist::disconnectMailingList(): Waitlist
+Waitlist::subscribeToMailingList(int|WaitlistEntry $entry): WaitlistEntry
+Waitlist::unsubscribeFromMailingList(int|WaitlistEntry $entry): WaitlistEntry
+Waitlist::syncMailingList(bool $force = false): int
+```
+
+### MailingList Facade Methods
+
+```php
+use OffloadProject\Waitlist\Facades\MailingList;
+
+MailingList::enabled(): bool
+MailingList::driver(?string $name = null): MailingListDriver
+MailingList::for(?Waitlist $waitlist = null): MailingListDriver
+MailingList::driverNameFor(?Waitlist $waitlist = null): string
+MailingList::listIdFor(?Waitlist $waitlist = null): ?string
+MailingList::tagEntry(WaitlistEntry $entry, array $tags): void
+MailingList::extend(string $name, Closure $callback): MailingListManager
+MailingList::fake(?string $listId = null): ArrayDriver  // Testing
+```
+
+Each driver implements `MailingListDriver`:
+
+```php
+$driver->subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+$driver->unsubscribe(WaitlistEntry $entry, string $listId): void
+$driver->tag(WaitlistEntry $entry, string $listId, array $tags): void
+$driver->find(string $email, string $listId): ?Subscriber
 ```
 
 ### Waitlist Model Methods
@@ -542,6 +744,12 @@ $waitlist->isActive(): bool
 // Status updates
 $waitlist->activate(): self
 $waitlist->deactivate(): self
+
+// Mailing list
+$waitlist->mailingListId(): ?string
+$waitlist->mailingListDriver(): ?string
+$waitlist->connectMailingList(string $listId, ?string $driver = null): self
+$waitlist->disconnectMailingList(): self
 ```
 
 ### WaitlistEntry Model Methods
@@ -561,6 +769,11 @@ $entry->markAsInvited(): self
 $entry->markAsRejected(): self
 $entry->markAsVerified(): self
 $entry->generateVerificationToken(): self
+
+// Mailing list
+$entry->isSubscribedToMailingList(): bool
+$entry->markAsSubscribed(string $driver, string $subscriberId): self
+$entry->markAsUnsubscribed(): self
 ```
 
 ## AI Coding Assistant Skill

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "notifications",
     "beta-access",
     "launch",
+    "mailchimp",
+    "convertkit",
+    "newsletter",
     "offload-project"
   ],
   "homepage": "https://github.com/offload-project/laravel-waitlist",

--- a/config/waitlist.php
+++ b/config/waitlist.php
@@ -91,6 +91,96 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Mailing List Integration
+    |--------------------------------------------------------------------------
+    |
+    | Push waitlist entries to a newsletter service such as Mailchimp or Kit.
+    | Connect a waitlist to a list with:
+    |
+    |     Waitlist::for('beta')->connectMailingList('audience-id');
+    |
+    | Entries are subscribed automatically: on sign up, or — when email
+    | verification is enabled — once the address has been verified.
+    |
+    */
+    'mailing_list' => [
+        'enabled' => env('WAITLIST_MAILING_LIST_ENABLED', false),
+
+        /*
+        | The driver used by waitlists that have not picked one themselves.
+        | Ships with: mailchimp, kit, log, array.
+        */
+        'default' => env('WAITLIST_MAILING_LIST_DRIVER', 'log'),
+
+        /*
+        | Subscribe entries automatically. Turn this off to sync by hand with
+        | Waitlist::subscribeToMailingList($entry) or by listening for events.
+        */
+        'auto_subscribe' => true,
+
+        /*
+        | Send new contacts a confirmation email before subscribing them.
+        | Mailchimp only — Kit uses the opt-in setting of the form itself.
+        */
+        'double_optin' => env('WAITLIST_MAILING_LIST_DOUBLE_OPTIN', false),
+
+        /*
+        | Tags applied to every subscriber the package creates.
+        */
+        'tags' => [],
+
+        /*
+        | A closure mapping an entry to provider fields (Mailchimp merge
+        | fields, Kit custom fields). Note that a config file containing a
+        | closure cannot be cached with `php artisan config:cache`.
+        | Example: fn(WaitlistEntry $entry) => ['SOURCE' => $entry->metadata['source'] ?? null]
+        */
+        'attributes' => null,
+
+        /*
+        | Syncing happens in a queued job so sign ups never wait on the API.
+        */
+        'queue' => [
+            'enabled' => true,
+            'connection' => env('WAITLIST_MAILING_LIST_QUEUE_CONNECTION'),
+            'queue' => env('WAITLIST_MAILING_LIST_QUEUE'),
+        ],
+
+        /*
+        | HTTP timeout in seconds, and how many times a failed request is
+        | retried before the job itself is retried.
+        */
+        'timeout' => 10,
+        'retries' => 2,
+
+        'drivers' => [
+            'mailchimp' => [
+                'key' => env('MAILCHIMP_API_KEY'),
+                // Data centre prefix, e.g. "us14". Derived from the key when null.
+                'server' => env('MAILCHIMP_SERVER_PREFIX'),
+                // Fallback audience id for waitlists with no list of their own.
+                'list_id' => env('MAILCHIMP_LIST_ID'),
+            ],
+
+            'kit' => [
+                'key' => env('KIT_API_KEY'),
+                // Whether a list id refers to a Kit "form" or a "tag".
+                'list_type' => env('KIT_LIST_TYPE', 'form'),
+                'list_id' => env('KIT_FORM_ID'),
+            ],
+
+            'log' => [
+                'channel' => env('WAITLIST_MAILING_LIST_LOG_CHANNEL'),
+                'list_id' => 'log',
+            ],
+
+            // Used by MailingList::fake(), which sets its own list id.
+            'array' => [],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Invitable Configuration
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/0001_01_01_000005_add_mailing_list_to_waitlist_entries_table.php
+++ b/database/migrations/0001_01_01_000005_add_mailing_list_to_waitlist_entries_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('waitlist_entries', function (Blueprint $table) {
+            $table->string('mailing_list_driver', 50)->nullable()->after('invitation_id');
+            $table->string('mailing_list_subscriber_id')->nullable()->after('mailing_list_driver');
+            $table->timestamp('mailing_list_synced_at')->nullable()->after('mailing_list_subscriber_id');
+
+            $table->index('mailing_list_synced_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('waitlist_entries', function (Blueprint $table) {
+            $table->dropIndex(['mailing_list_synced_at']);
+            $table->dropColumn([
+                'mailing_list_driver',
+                'mailing_list_subscriber_id',
+                'mailing_list_synced_at',
+            ]);
+        });
+    }
+};

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Laravel Waitlist
-description: Conventions and APIs for the offload-project/laravel-waitlist package — multiple waitlists, entry status tracking, optional email verification, and bridge into laravel-invite-only.
+description: Conventions and APIs for the offload-project/laravel-waitlist package — multiple waitlists, entry status tracking, optional email verification, lifecycle events, mailing list sync (Mailchimp/Kit), and bridge into laravel-invite-only.
 compatible_agents:
   - Claude Code
   - Cursor
@@ -11,6 +11,8 @@ tags:
   - eloquent
   - notifications
   - invitations
+  - mailing-list
+  - mailchimp
 ---
 
 ## Context
@@ -22,9 +24,11 @@ tags:
 - Optional email verification flow with a published `/waitlist/verify/{token}` route.
 - Optional bridge into `offload-project/laravel-invite-only`: calling `Waitlist::invite()` creates a real `Invitation` (token, expiration, events) and persists the FK on `WaitlistEntry::$invitation_id`.
 - Two notifications: `WaitlistInvited` (opt-in via `auto_send_invitation`) and `VerifyWaitlistEmail`.
-- A typed `UnverifiedEntryException` thrown when invite is attempted on an unverified entry while verification gating is on.
+- Lifecycle events in `OffloadProject\Waitlist\Events`: `WaitlistCreated`, `WaitlistEntryAdded`, `WaitlistEntryVerified`, `WaitlistEntryInvited`, `WaitlistEntryRejected`, plus `WaitlistEntrySubscribed`, `WaitlistEntryUnsubscribed`, and `MailingListSyncFailed`.
+- A mailing list integration (`MailingList` facade, `MailingListManager`) that syncs entries to Mailchimp or Kit (ConvertKit) in a queued job, with `log` and `array` drivers and an `extend()` hook for others.
+- Typed exceptions: `UnverifiedEntryException` (invite attempted on an unverified entry while verification gating is on) and `MailingListException` (driver/credential/list-id/API failures).
 
-Apply this skill when working in a Laravel app that has `offload-project/laravel-waitlist` in `composer.json`, or when the user asks for help with `Waitlist`, `WaitlistEntry`, the `Waitlist` facade, or waitlist flows in this package.
+Apply this skill when working in a Laravel app that has `offload-project/laravel-waitlist` in `composer.json`, or when the user asks for help with `Waitlist`, `WaitlistEntry`, the `Waitlist` or `MailingList` facades, or waitlist flows in this package.
 
 ## Rules
 
@@ -68,11 +72,26 @@ Apply this skill when working in a Laravel app that has `offload-project/laravel
     - `invitable.metadata_mapper` — closure `fn(WaitlistEntry $entry) => array` to translate entry metadata into invitation metadata (e.g. `['role' => 'beta-tester']`).
 19. Don't hard-code an invitable per call site. If different flows need different invitables, use the `resolver` closure with a discriminator in `metadata`.
 
+### Events
+
+20. Hook into the lifecycle with the package's own events rather than wrapping the facade or polling the table. They live in `OffloadProject\Waitlist\Events` and each carries the model as a readonly property (`$event->entry`, `$event->waitlist`).
+21. The lifecycle events fire from the models (`WaitlistEntryAdded` via `$dispatchesEvents` on create; the rest from `markAsInvited()` / `markAsRejected()` / `markAsVerified()`), so listeners still run for code that bypasses the facade.
+22. Use `Event::fake([SpecificEvent::class])` in tests, not a bare `Event::fake()` — a blanket fake also swallows `WaitlistEntryAdded`, which stops the mailing list listener from ever running.
+
+### Mailing list sync
+
+23. Turn it on with `waitlist.mailing_list.enabled` and pick a driver (`mailchimp`, `kit`, `log`, `array`). Connect a waitlist to a list with `Waitlist::for($slug)->connectMailingList($listId, $driver = null)` — the list id is a Mailchimp audience id, or a Kit form id (or tag id when `list_type` is `tag`). Waitlists with no list of their own fall back to the driver's configured `list_id`.
+24. Don't build your own "subscribe on sign up" listener. Subscribing is automatic and follows the verification setting: with `waitlist.verification.enabled` off the entry syncs on `add()`, with it on the entry syncs after `Waitlist::verify()`. That ordering is deliberate — an unconfirmed address must never reach the newsletter.
+25. For anything beyond subscribing — tagging on invite, removing on reject, moving between lists — listen for the lifecycle events and call `MailingList::tagEntry($entry, [...])` or `Waitlist::unsubscribeFromMailingList($entry)`. Don't add those side effects inside the host app's controllers.
+26. Syncing runs through queued jobs (`SyncEntryToMailingList`, `UnsubscribeEntryFromMailingList`). Keep `mailing_list.queue.enabled` on in production so sign ups never block on the provider's API. Backfill existing rows with `php artisan waitlist:sync-mailing-list [slug] [--all] [--force]` or `Waitlist::for($slug)->syncMailingList()`.
+27. Add a service the package doesn't ship by implementing `OffloadProject\Waitlist\Contracts\MailingListDriver` and registering it with `MailingList::extend('name', fn (array $config) => new YourDriver(...))` from a service provider. Don't fork the shipped drivers.
+28. In tests use `MailingList::fake()`, which swaps in the in-memory `ArrayDriver`, runs syncs inline, and exposes `hasSubscriber()`, `subscribers()`, and `tagsFor()`. Reach for `Http::fake()` only when asserting the exact request a real driver sends.
+
 ### Don'ts
 
-20. Don't run lifecycle changes via direct `update()` calls (`$entry->update(['status' => 'invited'])`). Use `markAsInvited()` / `markAsRejected()` / `markAsVerified()` so casts and side effects (timestamps, token clearing) stay consistent. Better still: drive everything through the facade.
-21. Don't edit the published migrations to add columns — write a follow-up migration in the host app. The package may add columns in future releases and will assume the published schema.
-22. Don't subclass `Waitlist` or `WaitlistEntry`; both are `final`. Add behavior on the host-app side via event listeners on the underlying `laravel-invite-only` events, or by extending the service via a custom binding in your app's container.
+29. Don't run lifecycle changes via direct `update()` calls (`$entry->update(['status' => 'invited'])`). Use `markAsInvited()` / `markAsRejected()` / `markAsVerified()` so casts, side effects (timestamps, token clearing), and events stay consistent. Better still: drive everything through the facade.
+30. Don't edit the published migrations to add columns — write a follow-up migration in the host app. The package may add columns in future releases and will assume the published schema.
+31. Don't subclass `Waitlist` or `WaitlistEntry`; both are `final`. Add behavior on the host-app side via listeners on the package's events, or by extending the service via a custom binding in your app's container.
 
 ## Examples
 
@@ -188,6 +207,55 @@ class CustomVerifyWaitlistEmail extends Notification
 ],
 ```
 
+### Syncing sign-ups to Mailchimp
+
+```php
+// config/waitlist.php
+'mailing_list' => [
+    'enabled' => true,
+    'default' => 'mailchimp',
+    'drivers' => [
+        'mailchimp' => [
+            'key' => env('MAILCHIMP_API_KEY'),   // suffix carries the data centre, e.g. -us14
+            'list_id' => env('MAILCHIMP_LIST_ID'),
+        ],
+    ],
+],
+```
+
+```php
+// One audience per waitlist (optional — otherwise the config list_id is used).
+Waitlist::for('beta')->connectMailingList('a1b2c3d4e5');
+
+// Subscribed automatically, on add or on verification depending on the config.
+Waitlist::for('beta')->add('Jane Smith', 'jane@example.com');
+```
+
+### Reacting to the lifecycle
+
+```php
+use Illuminate\Support\Facades\Event;
+use OffloadProject\Waitlist\Events\WaitlistEntryInvited;
+use OffloadProject\Waitlist\Events\WaitlistEntryRejected;
+use OffloadProject\Waitlist\Facades\MailingList;
+use OffloadProject\Waitlist\Facades\Waitlist;
+
+Event::listen(fn (WaitlistEntryInvited $event) => MailingList::tagEntry($event->entry, ['invited']));
+Event::listen(fn (WaitlistEntryRejected $event) => Waitlist::unsubscribeFromMailingList($event->entry));
+```
+
+### Testing a mailing list flow
+
+```php
+use OffloadProject\Waitlist\Facades\MailingList;
+
+$mailingList = MailingList::fake();
+
+Waitlist::add('John Doe', 'john@example.com');
+
+expect($mailingList->hasSubscriber('john@example.com'))->toBeTrue();
+```
+
 ### Disabling package routes (own controller)
 
 ```php
@@ -211,7 +279,11 @@ Route::get('/welcome/{token}', function (string $token) {
 - ❌ `$entry->update(['status' => 'invited'])` instead of `Waitlist::invite($entry)`. The direct update skips the `laravel-invite-only` invitation, the token, the notification, and the FK linkage.
 - ❌ Catching `\Throwable` or `\Exception` around `Waitlist::invite()`. Catch `UnverifiedEntryException` (and the invite-only typed exceptions) so each failure mode produces a tailored response.
 - ❌ Toggling `waitlist.auto_send_invitation` to `true` without also customizing `waitlist.notification`. By default both `WaitlistInvited` and the invite-only invitation notification will fire — two emails per invite.
-- ❌ Subclassing `Waitlist` or `WaitlistEntry`. Both are `final`; extend behavior via events on `laravel-invite-only` or a custom service binding.
+- ❌ Subclassing `Waitlist` or `WaitlistEntry`. Both are `final`; extend behavior via the package's events or a custom service binding.
+- ❌ Calling a mailing list API from a controller after `Waitlist::add(...)`. Subscribing is already automatic — a manual call double-subscribes and skips the queue.
+- ❌ Subscribing unverified entries when verification is on (e.g. by listening for `WaitlistEntryAdded` yourself). Listen for `WaitlistEntryVerified` instead, or just let the package do it.
+- ❌ Writing a mailing list `list_id` into `waitlist_entries.metadata`. Lists belong to the waitlist — store them with `connectMailingList()`, which lives in the `waitlists.settings` column.
+- ❌ Putting a closure in `mailing_list.attributes` and then running `php artisan config:cache`. Config files containing closures cannot be cached.
 - ❌ Hard-coding `'invited_by' => auth()->user()` at every call site. Omit it and let `WaitlistService` fall back to `auth()->user()` automatically. Pass it explicitly only when you need a different actor (admin acting on behalf, console command, etc.).
 - ❌ Editing files inside `vendor/offload-project/laravel-waitlist`. All extension points are exposed via `config/waitlist.php`.
 - ❌ Sharing one email between waitlists via a single global `email` unique constraint. The package already supports a person on multiple waitlists — the constraint is `['waitlist_id', 'email']`. Don't add app-level deduplication that fights this.

--- a/src/Console/SyncMailingListCommand.php
+++ b/src/Console/SyncMailingListCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use OffloadProject\Waitlist\MailingList\MailingListManager;
+use OffloadProject\Waitlist\Models\Waitlist;
+use OffloadProject\Waitlist\WaitlistService;
+
+final class SyncMailingListCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'waitlist:sync-mailing-list
+                            {waitlist? : The slug of the waitlist to sync}
+                            {--all : Sync every waitlist}
+                            {--force : Re-sync entries that have already been synced}';
+
+    /** @var string */
+    protected $description = 'Push waitlist entries to their connected mailing list';
+
+    public function handle(WaitlistService $waitlist, MailingListManager $mailingList): int
+    {
+        if (! $mailingList->enabled()) {
+            $this->components->error('Mailing list syncing is disabled. Set [waitlist.mailing_list.enabled] to true.');
+
+            return self::FAILURE;
+        }
+
+        $waitlists = $this->waitlists($waitlist);
+
+        if ($waitlists->isEmpty()) {
+            $this->components->error('No matching waitlist found.');
+
+            return self::FAILURE;
+        }
+
+        $total = 0;
+
+        foreach ($waitlists as $list) {
+            if ($mailingList->listIdFor($list) === null) {
+                $this->components->twoColumnDetail($list->name, '<fg=yellow>no list connected</>');
+
+                continue;
+            }
+
+            $queued = $waitlist->for($list)->syncMailingList((bool) $this->option('force'));
+            $total += $queued;
+
+            $this->components->twoColumnDetail(
+                "{$list->name} <fg=gray>({$mailingList->driverNameFor($list)})</>",
+                "{$queued} queued"
+            );
+        }
+
+        $this->components->info("Queued {$total} ".str('entry')->plural($total).' for syncing.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, Waitlist>
+     */
+    private function waitlists(WaitlistService $waitlist): Collection
+    {
+        if ($this->option('all')) {
+            return Waitlist::all();
+        }
+
+        $slug = $this->argument('waitlist');
+
+        if (! is_string($slug)) {
+            return new Collection([$waitlist->getDefault()]);
+        }
+
+        return Waitlist::where('slug', $slug)->get();
+    }
+}

--- a/src/Contracts/MailingListDriver.php
+++ b/src/Contracts/MailingListDriver.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Contracts;
+
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+interface MailingListDriver
+{
+    /**
+     * The name this driver is registered under.
+     */
+    public function name(): string;
+
+    /**
+     * Add (or update) the entry on the given list.
+     *
+     * The $listId is provider specific: a Mailchimp audience id, a Kit form
+     * or tag id, and so on.
+     *
+     * @param  array{tags?: array<array-key, string>, double_optin?: bool, attributes?: array<string, mixed>}  $options
+     *
+     * @throws MailingListException
+     */
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber;
+
+    /**
+     * Unsubscribe the entry from the given list.
+     *
+     * @throws MailingListException
+     */
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void;
+
+    /**
+     * Apply tags to the entry on the given list.
+     *
+     * @param  list<string>  $tags
+     *
+     * @throws MailingListException
+     */
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void;
+
+    /**
+     * Look up a subscriber by email, or null when they are not on the list.
+     *
+     * @throws MailingListException
+     */
+    public function find(string $email, string $listId): ?Subscriber;
+}

--- a/src/Events/MailingListSyncFailed.php
+++ b/src/Events/MailingListSyncFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+use Throwable;
+
+final class MailingListSyncFailed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry,
+        public readonly string $driver,
+        public readonly Throwable $exception,
+    ) {}
+}

--- a/src/Events/WaitlistCreated.php
+++ b/src/Events/WaitlistCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\Waitlist;
+
+final class WaitlistCreated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly Waitlist $waitlist
+    ) {}
+}

--- a/src/Events/WaitlistEntryAdded.php
+++ b/src/Events/WaitlistEntryAdded.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntryAdded
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry
+    ) {}
+}

--- a/src/Events/WaitlistEntryInvited.php
+++ b/src/Events/WaitlistEntryInvited.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntryInvited
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry
+    ) {}
+}

--- a/src/Events/WaitlistEntryRejected.php
+++ b/src/Events/WaitlistEntryRejected.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntryRejected
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry
+    ) {}
+}

--- a/src/Events/WaitlistEntrySubscribed.php
+++ b/src/Events/WaitlistEntrySubscribed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntrySubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry,
+        public readonly Subscriber $subscriber,
+        public readonly string $driver,
+    ) {}
+}

--- a/src/Events/WaitlistEntryUnsubscribed.php
+++ b/src/Events/WaitlistEntryUnsubscribed.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntryUnsubscribed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry,
+        public readonly string $driver,
+    ) {}
+}

--- a/src/Events/WaitlistEntryVerified.php
+++ b/src/Events/WaitlistEntryVerified.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class WaitlistEntryVerified
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly WaitlistEntry $entry
+    ) {}
+}

--- a/src/Exceptions/MailingListException.php
+++ b/src/Exceptions/MailingListException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Exceptions;
+
+use Exception;
+
+final class MailingListException extends Exception
+{
+    public static function driverNotSupported(string $driver): self
+    {
+        return new self("Mailing list driver [{$driver}] is not supported.");
+    }
+
+    public static function missingCredentials(string $driver, string $key): self
+    {
+        return new self("Mailing list driver [{$driver}] is missing the [{$key}] credential. Set it in config/waitlist.php.");
+    }
+
+    public static function missingListId(string $driver): self
+    {
+        return new self("No mailing list id configured for driver [{$driver}]. Connect the waitlist with Waitlist::for(\$slug)->connectMailingList(\$listId) or set a default list id in config/waitlist.php.");
+    }
+
+    public static function requestFailed(string $driver, string $message, int $status): self
+    {
+        return new self("Mailing list request to [{$driver}] failed with status {$status}: {$message}");
+    }
+}

--- a/src/Facades/MailingList.php
+++ b/src/Facades/MailingList.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\ArrayDriver;
+use OffloadProject\Waitlist\MailingList\MailingListManager;
+use OffloadProject\Waitlist\Models\Waitlist;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * @method static bool enabled()
+ * @method static string getDefaultDriver()
+ * @method static MailingListDriver driver(string|null $name = null)
+ * @method static MailingListDriver for(Waitlist|null $waitlist = null)
+ * @method static string driverNameFor(Waitlist|null $waitlist = null)
+ * @method static string|null listIdFor(Waitlist|null $waitlist = null)
+ * @method static void tagEntry(WaitlistEntry $entry, list<string> $tags)
+ * @method static MailingListManager extend(string $name, Closure $callback)
+ * @method static MailingListManager forget(string|null $name = null)
+ * @method static ArrayDriver fake(string|null $listId = null)
+ *
+ * @see MailingListManager
+ */
+final class MailingList extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'waitlist.mailing-list';
+    }
+}

--- a/src/Jobs/SyncEntryToMailingList.php
+++ b/src/Jobs/SyncEntryToMailingList.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Events\MailingListSyncFailed;
+use OffloadProject\Waitlist\Events\WaitlistEntrySubscribed;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\MailingListManager;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+use Throwable;
+
+final class SyncEntryToMailingList implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public WaitlistEntry $entry
+    ) {}
+
+    /**
+     * Queue the sync, or run it inline when queueing is turned off.
+     */
+    public static function dispatchFor(WaitlistEntry $entry): void
+    {
+        $job = new self($entry);
+
+        if (! config('waitlist.mailing_list.queue.enabled', true)) {
+            dispatch_sync($job);
+
+            return;
+        }
+
+        // Entries are often created inside a transaction, so wait for the
+        // commit rather than letting a worker beat it to the row.
+        dispatch($job)
+            ->afterCommit()
+            ->onConnection(config('waitlist.mailing_list.queue.connection'))
+            ->onQueue(config('waitlist.mailing_list.queue.queue'));
+    }
+
+    public function handle(MailingListManager $mailingList): void
+    {
+        $waitlist = $this->entry->waitlist;
+        $driver = $mailingList->driverNameFor($waitlist);
+        $listId = $mailingList->listIdFor($waitlist);
+
+        if ($listId === null) {
+            // A missing list id is a configuration problem: retrying it will
+            // never succeed, so report it and stop here.
+            $exception = MailingListException::missingListId($driver);
+
+            report($exception);
+            event(new MailingListSyncFailed($this->entry, $driver, $exception));
+
+            return;
+        }
+
+        try {
+            $subscriber = $mailingList->driver($driver)->subscribe($this->entry, $listId);
+        } catch (Throwable $exception) {
+            event(new MailingListSyncFailed($this->entry, $driver, $exception));
+
+            throw $exception;
+        }
+
+        $this->entry->markAsSubscribed($driver, $subscriber->id);
+
+        event(new WaitlistEntrySubscribed($this->entry, $subscriber, $driver));
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return [10, 60];
+    }
+}

--- a/src/Jobs/UnsubscribeEntryFromMailingList.php
+++ b/src/Jobs/UnsubscribeEntryFromMailingList.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use OffloadProject\Waitlist\Events\MailingListSyncFailed;
+use OffloadProject\Waitlist\Events\WaitlistEntryUnsubscribed;
+use OffloadProject\Waitlist\MailingList\MailingListManager;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+use Throwable;
+
+final class UnsubscribeEntryFromMailingList implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public WaitlistEntry $entry
+    ) {}
+
+    /**
+     * Queue the removal, or run it inline when queueing is turned off.
+     */
+    public static function dispatchFor(WaitlistEntry $entry): void
+    {
+        $job = new self($entry);
+
+        if (! config('waitlist.mailing_list.queue.enabled', true)) {
+            dispatch_sync($job);
+
+            return;
+        }
+
+        dispatch($job)
+            ->afterCommit()
+            ->onConnection(config('waitlist.mailing_list.queue.connection'))
+            ->onQueue(config('waitlist.mailing_list.queue.queue'));
+    }
+
+    public function handle(MailingListManager $mailingList): void
+    {
+        $waitlist = $this->entry->waitlist;
+        $driver = $this->entry->mailing_list_driver ?? $mailingList->driverNameFor($waitlist);
+        $listId = $mailingList->listIdFor($waitlist);
+
+        if ($listId === null) {
+            return;
+        }
+
+        try {
+            $mailingList->driver($driver)->unsubscribe($this->entry, $listId);
+        } catch (Throwable $exception) {
+            event(new MailingListSyncFailed($this->entry, $driver, $exception));
+
+            throw $exception;
+        }
+
+        $this->entry->markAsUnsubscribed();
+
+        event(new WaitlistEntryUnsubscribed($this->entry, $driver));
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return [10, 60];
+    }
+}

--- a/src/Listeners/SubscribeEntryToMailingList.php
+++ b/src/Listeners/SubscribeEntryToMailingList.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\Listeners;
+
+use OffloadProject\Waitlist\Events\WaitlistEntryAdded;
+use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
+use OffloadProject\Waitlist\Jobs\SyncEntryToMailingList;
+
+final class SubscribeEntryToMailingList
+{
+    public function handle(WaitlistEntryAdded|WaitlistEntryVerified $event): void
+    {
+        if (! config('waitlist.mailing_list.enabled', false)) {
+            return;
+        }
+
+        if (! config('waitlist.mailing_list.auto_subscribe', true)) {
+            return;
+        }
+
+        $awaitingVerification = (bool) config('waitlist.verification.enabled', false);
+
+        // With verification turned on we hold off until the address is
+        // confirmed; without it, we subscribe as soon as the entry is added.
+        if ($awaitingVerification !== ($event instanceof WaitlistEntryVerified)) {
+            return;
+        }
+
+        SyncEntryToMailingList::dispatchFor($event->entry);
+    }
+}

--- a/src/MailingList/Concerns/ResolvesEntryAttributes.php
+++ b/src/MailingList/Concerns/ResolvesEntryAttributes.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Concerns;
+
+use Illuminate\Support\Str;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+trait ResolvesEntryAttributes
+{
+    private function firstName(WaitlistEntry $entry): string
+    {
+        return Str::before($entry->name, ' ');
+    }
+
+    private function lastName(WaitlistEntry $entry): string
+    {
+        return str_contains($entry->name, ' ') ? Str::after($entry->name, ' ') : '';
+    }
+
+    /**
+     * Merge the configured attribute mapper with any per-call attributes.
+     *
+     * @param  array{attributes?: array<string, mixed>}  $options
+     * @return array<string, mixed>
+     */
+    private function attributes(WaitlistEntry $entry, array $options): array
+    {
+        /** @var callable|null $mapper */
+        $mapper = config('waitlist.mailing_list.attributes');
+
+        $mapped = $mapper !== null ? $mapper($entry) : [];
+
+        return array_merge($mapped, $options['attributes'] ?? []);
+    }
+
+    /**
+     * @param  array{tags?: array<array-key, string>}  $options
+     * @return list<string>
+     */
+    private function tags(array $options): array
+    {
+        /** @var array<array-key, string> $tags */
+        $tags = $options['tags'] ?? config('waitlist.mailing_list.tags', []);
+
+        return array_values($tags);
+    }
+
+    /**
+     * @param  array{double_optin?: bool}  $options
+     */
+    private function wantsDoubleOptIn(array $options): bool
+    {
+        return (bool) ($options['double_optin'] ?? config('waitlist.mailing_list.double_optin', false));
+    }
+}

--- a/src/MailingList/Drivers/ArrayDriver.php
+++ b/src/MailingList/Drivers/ArrayDriver.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\MailingList\Concerns\ResolvesEntryAttributes;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * In-memory driver used by MailingList::fake() so tests can assert on what
+ * would have been sent without hitting a real service.
+ */
+final class ArrayDriver implements MailingListDriver
+{
+    use ResolvesEntryAttributes;
+
+    /** @var array<string, array<string, Subscriber>> */
+    private array $subscribers = [];
+
+    /** @var array<string, array<string, list<string>>> */
+    private array $tags = [];
+
+    public function name(): string
+    {
+        return 'array';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        $subscriber = new Subscriber(
+            id: md5(mb_strtolower($entry->email)),
+            email: $entry->email,
+            status: $this->wantsDoubleOptIn($options) ? 'pending' : 'subscribed',
+            raw: ['attributes' => $this->attributes($entry, $options)],
+        );
+
+        $this->subscribers[$listId][$this->key($entry->email)] = $subscriber;
+
+        $tags = $this->tags($options);
+
+        if ($tags !== []) {
+            $this->tag($entry, $listId, $tags);
+        }
+
+        return $subscriber;
+    }
+
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        unset(
+            $this->subscribers[$listId][$this->key($entry->email)],
+            $this->tags[$listId][$this->key($entry->email)],
+        );
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        $existing = $this->tags[$listId][$this->key($entry->email)] ?? [];
+
+        $this->tags[$listId][$this->key($entry->email)] = array_values(
+            array_unique(array_merge($existing, $tags))
+        );
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        return $this->subscribers[$listId][$this->key($email)] ?? null;
+    }
+
+    /**
+     * Every subscriber on a list, or across all lists when no list is given.
+     *
+     * @return array<string, Subscriber>
+     */
+    public function subscribers(?string $listId = null): array
+    {
+        if ($listId !== null) {
+            return $this->subscribers[$listId] ?? [];
+        }
+
+        return array_merge(...array_values($this->subscribers)) ?: [];
+    }
+
+    public function hasSubscriber(string $email, ?string $listId = null): bool
+    {
+        return array_key_exists($this->key($email), $this->subscribers($listId));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function tagsFor(string $email, string $listId): array
+    {
+        return $this->tags[$listId][$this->key($email)] ?? [];
+    }
+
+    public function flush(): void
+    {
+        $this->subscribers = [];
+        $this->tags = [];
+    }
+
+    private function key(string $email): string
+    {
+        return mb_strtolower($email);
+    }
+}

--- a/src/MailingList/Drivers/KitDriver.php
+++ b/src/MailingList/Drivers/KitDriver.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Concerns\ResolvesEntryAttributes;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * Kit (formerly ConvertKit) API v4.
+ *
+ * Kit has no concept of separate lists: subscribers live on the account and
+ * are segmented by form or tag. The list id is therefore a form id (default)
+ * or a tag id, depending on the driver's `list_type` config.
+ *
+ * @see https://developers.kit.com/api-reference/
+ */
+final class KitDriver implements MailingListDriver
+{
+    use ResolvesEntryAttributes;
+
+    /** @var array<string, string> */
+    private array $tagIds = [];
+
+    public function __construct(
+        private readonly string $key,
+        private readonly string $listType = 'form',
+        private readonly int $timeout = 10,
+        private readonly int $retries = 2,
+    ) {}
+
+    public function name(): string
+    {
+        return 'kit';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        // Upserts the subscriber so custom fields are stored before they are
+        // attached to the form or tag.
+        $response = $this->request()->post('/subscribers', array_filter([
+            'email_address' => $entry->email,
+            'first_name' => $this->firstName($entry),
+            'fields' => $this->attributes($entry, $options),
+        ]));
+
+        $this->throwUnlessSuccessful($response);
+
+        $subscriber = $this->toSubscriber($response->json('subscriber'));
+
+        // Kit honours the form's own double opt-in setting here, so the
+        // package's double_optin option does not apply to this driver.
+        $this->throwUnlessSuccessful(
+            $this->request()->post("/{$this->collection()}/{$listId}/subscribers", [
+                'email_address' => $entry->email,
+            ])
+        );
+
+        $tags = $this->tags($options);
+
+        if ($tags !== []) {
+            $this->tag($entry, $listId, $tags);
+        }
+
+        return $subscriber;
+    }
+
+    /**
+     * Kit unsubscribes are account wide rather than per form.
+     */
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        $subscriberId = $this->subscriberId($entry, $listId);
+
+        if ($subscriberId === null) {
+            return;
+        }
+
+        $this->throwUnlessSuccessful(
+            $this->request()->post("/subscribers/{$subscriberId}/unsubscribe")
+        );
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        foreach ($tags as $tag) {
+            $this->throwUnlessSuccessful(
+                $this->request()->post("/tags/{$this->tagId($tag)}/subscribers", [
+                    'email_address' => $entry->email,
+                ])
+            );
+        }
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        $response = $this->request()->get('/subscribers', ['email_address' => $email]);
+
+        $this->throwUnlessSuccessful($response);
+
+        /** @var array<int, array<string, mixed>> $subscribers */
+        $subscribers = $response->json('subscribers', []);
+
+        if ($subscribers === []) {
+            return null;
+        }
+
+        return $this->toSubscriber($subscribers[0]);
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl('https://api.kit.com/v4')
+            ->withHeaders(['X-Kit-Api-Key' => $this->key])
+            ->timeout($this->timeout)
+            ->retry(max(1, $this->retries), 250, throw: false)
+            ->acceptJson();
+    }
+
+    private function collection(): string
+    {
+        return $this->listType === 'tag' ? 'tags' : 'forms';
+    }
+
+    private function subscriberId(WaitlistEntry $entry, string $listId): ?string
+    {
+        if ($entry->mailing_list_driver === $this->name() && filled($entry->mailing_list_subscriber_id)) {
+            return $entry->mailing_list_subscriber_id;
+        }
+
+        return $this->find($entry->email, $listId)?->id;
+    }
+
+    /**
+     * Resolve a tag name to its id, creating the tag when it does not exist.
+     */
+    private function tagId(string $tag): string
+    {
+        if (isset($this->tagIds[$tag])) {
+            return $this->tagIds[$tag];
+        }
+
+        $response = $this->request()->get('/tags', ['per_page' => 500]);
+
+        $this->throwUnlessSuccessful($response);
+
+        /** @var array<int, array{id?: int|string, name?: string}> $existing */
+        $existing = $response->json('tags', []);
+
+        foreach ($existing as $candidate) {
+            if (isset($candidate['name'], $candidate['id']) && $candidate['name'] === $tag) {
+                return $this->tagIds[$tag] = (string) $candidate['id'];
+            }
+        }
+
+        $created = $this->request()->post('/tags', ['name' => $tag]);
+
+        $this->throwUnlessSuccessful($created);
+
+        return $this->tagIds[$tag] = (string) $created->json('tag.id');
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function toSubscriber(?array $payload): Subscriber
+    {
+        $payload ??= [];
+
+        return new Subscriber(
+            id: (string) ($payload['id'] ?? ''),
+            email: (string) ($payload['email_address'] ?? ''),
+            status: isset($payload['state']) ? (string) $payload['state'] : null,
+            raw: $payload,
+        );
+    }
+
+    private function throwUnlessSuccessful(Response $response): void
+    {
+        if ($response->successful()) {
+            return;
+        }
+
+        /** @var array<int, string>|null $errors */
+        $errors = $response->json('errors');
+
+        throw MailingListException::requestFailed(
+            'kit',
+            $errors !== null ? implode(' ', $errors) : $response->body(),
+            $response->status(),
+        );
+    }
+}

--- a/src/MailingList/Drivers/LogDriver.php
+++ b/src/MailingList/Drivers/LogDriver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use Illuminate\Support\Facades\Log;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * Writes what would have been sent to the log. Useful in local and staging
+ * environments where you do not want to touch a real audience.
+ */
+final class LogDriver implements MailingListDriver
+{
+    public function __construct(
+        private readonly ?string $channel = null,
+    ) {}
+
+    public function name(): string
+    {
+        return 'log';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        $this->log('subscribe', $entry, $listId, $options);
+
+        return new Subscriber(
+            id: md5(mb_strtolower($entry->email)),
+            email: $entry->email,
+            status: 'subscribed',
+        );
+    }
+
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        $this->log('unsubscribe', $entry, $listId);
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        $this->log('tag', $entry, $listId, ['tags' => $tags]);
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function log(string $action, WaitlistEntry $entry, string $listId, array $context = []): void
+    {
+        Log::channel($this->channel ?? config('logging.default'))->info(
+            "Waitlist mailing list [{$action}]",
+            array_merge([
+                'entry_id' => $entry->id,
+                'email' => $entry->email,
+                'list_id' => $listId,
+            ], $context)
+        );
+    }
+}

--- a/src/MailingList/Drivers/MailchimpDriver.php
+++ b/src/MailingList/Drivers/MailchimpDriver.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Concerns\ResolvesEntryAttributes;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * Mailchimp Marketing API v3.
+ *
+ * The list id is an audience id, found under Audience > Settings > Audience
+ * name and defaults in the Mailchimp dashboard.
+ *
+ * @see https://mailchimp.com/developer/marketing/api/list-members/
+ */
+final class MailchimpDriver implements MailingListDriver
+{
+    use ResolvesEntryAttributes;
+
+    public function __construct(
+        private readonly string $key,
+        private readonly ?string $server = null,
+        private readonly int $timeout = 10,
+        private readonly int $retries = 2,
+    ) {}
+
+    public function name(): string
+    {
+        return 'mailchimp';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        $payload = [
+            'email_address' => $entry->email,
+            // Only sent on create, so an existing unsubscribe is never overridden.
+            'status_if_new' => $this->wantsDoubleOptIn($options) ? 'pending' : 'subscribed',
+            'merge_fields' => $this->mergeFields($entry, $options),
+        ];
+
+        $response = $this->request()->put($this->memberPath($listId, $entry->email), $payload);
+
+        $this->throwUnlessSuccessful($response);
+
+        $tags = $this->tags($options);
+
+        if ($tags !== []) {
+            $this->tag($entry, $listId, $tags);
+        }
+
+        return $this->toSubscriber($response->json());
+    }
+
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        $response = $this->request()->patch($this->memberPath($listId, $entry->email), [
+            'status' => 'unsubscribed',
+        ]);
+
+        // A contact that was never synced is already in the desired state.
+        if ($response->status() === 404) {
+            return;
+        }
+
+        $this->throwUnlessSuccessful($response);
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        if ($tags === []) {
+            return;
+        }
+
+        $response = $this->request()->post($this->memberPath($listId, $entry->email).'/tags', [
+            'tags' => array_map(
+                fn (string $tag): array => ['name' => $tag, 'status' => 'active'],
+                $tags
+            ),
+        ]);
+
+        $this->throwUnlessSuccessful($response);
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        $response = $this->request()->get($this->memberPath($listId, $email));
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        $this->throwUnlessSuccessful($response);
+
+        return $this->toSubscriber($response->json());
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl("https://{$this->server()}.api.mailchimp.com/3.0")
+            ->withBasicAuth('laravel-waitlist', $this->key)
+            ->timeout($this->timeout)
+            ->retry(max(1, $this->retries), 250, throw: false)
+            ->acceptJson();
+    }
+
+    /**
+     * Mailchimp derives the data centre from the suffix of the API key.
+     */
+    private function server(): string
+    {
+        if (filled($this->server)) {
+            return $this->server;
+        }
+
+        $suffix = Str::afterLast($this->key, '-');
+
+        if ($suffix === '' || $suffix === $this->key) {
+            throw MailingListException::missingCredentials('mailchimp', 'server');
+        }
+
+        return $suffix;
+    }
+
+    private function memberPath(string $listId, string $email): string
+    {
+        return "/lists/{$listId}/members/".md5(mb_strtolower($email));
+    }
+
+    /**
+     * @param  array{attributes?: array<string, mixed>}  $options
+     * @return array<string, mixed>
+     */
+    private function mergeFields(WaitlistEntry $entry, array $options): array
+    {
+        return array_merge([
+            'FNAME' => $this->firstName($entry),
+            'LNAME' => $this->lastName($entry),
+        ], $this->attributes($entry, $options));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function toSubscriber(?array $payload): Subscriber
+    {
+        $payload ??= [];
+
+        return new Subscriber(
+            id: (string) ($payload['id'] ?? ''),
+            email: (string) ($payload['email_address'] ?? ''),
+            status: isset($payload['status']) ? (string) $payload['status'] : null,
+            raw: $payload,
+        );
+    }
+
+    private function throwUnlessSuccessful(Response $response): void
+    {
+        if ($response->successful()) {
+            return;
+        }
+
+        throw MailingListException::requestFailed(
+            'mailchimp',
+            (string) ($response->json('detail') ?? $response->body()),
+            $response->status(),
+        );
+    }
+}

--- a/src/MailingList/MailingListManager.php
+++ b/src/MailingList/MailingListManager.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList;
+
+use Closure;
+use Illuminate\Support\Facades\Config;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Drivers\ArrayDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\KitDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\LogDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\MailchimpDriver;
+use OffloadProject\Waitlist\Models\Waitlist;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+final class MailingListManager
+{
+    /** @var array<string, MailingListDriver> */
+    private array $drivers = [];
+
+    /** @var array<string, Closure(array<string, mixed>): MailingListDriver> */
+    private array $customCreators = [];
+
+    public function enabled(): bool
+    {
+        return (bool) config('waitlist.mailing_list.enabled', false);
+    }
+
+    public function getDefaultDriver(): string
+    {
+        return (string) config('waitlist.mailing_list.default', 'log');
+    }
+
+    public function driver(?string $name = null): MailingListDriver
+    {
+        $name ??= $this->getDefaultDriver();
+
+        return $this->drivers[$name] ??= $this->resolve($name);
+    }
+
+    /**
+     * Resolve the driver a given waitlist should sync to.
+     */
+    public function for(?Waitlist $waitlist = null): MailingListDriver
+    {
+        return $this->driver($this->driverNameFor($waitlist));
+    }
+
+    public function driverNameFor(?Waitlist $waitlist = null): string
+    {
+        return $waitlist?->mailingListDriver() ?? $this->getDefaultDriver();
+    }
+
+    /**
+     * The list a waitlist syncs into, falling back to the driver's default.
+     */
+    public function listIdFor(?Waitlist $waitlist = null): ?string
+    {
+        $listId = $waitlist?->mailingListId();
+
+        if (filled($listId)) {
+            return $listId;
+        }
+
+        $fallback = config("waitlist.mailing_list.drivers.{$this->driverNameFor($waitlist)}.list_id");
+
+        return filled($fallback) ? (string) $fallback : null;
+    }
+
+    /**
+     * Tag an entry on whichever list its waitlist is connected to.
+     *
+     * @param  list<string>  $tags
+     */
+    public function tagEntry(WaitlistEntry $entry, array $tags): void
+    {
+        $waitlist = $entry->waitlist;
+        $listId = $this->listIdFor($waitlist);
+
+        if ($listId === null) {
+            return;
+        }
+
+        $this->for($waitlist)->tag($entry, $listId, $tags);
+    }
+
+    /**
+     * Register a driver of your own.
+     *
+     * @param  Closure(array<string, mixed>): MailingListDriver  $callback
+     */
+    public function extend(string $name, Closure $callback): self
+    {
+        $this->customCreators[$name] = $callback;
+
+        unset($this->drivers[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Drop resolved drivers so they pick up configuration changes.
+     */
+    public function forget(?string $name = null): self
+    {
+        if ($name === null) {
+            $this->drivers = [];
+
+            return $this;
+        }
+
+        unset($this->drivers[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Swap in the in-memory driver for tests, and run syncs inline so
+     * assertions can run straight after the call under test.
+     */
+    public function fake(?string $listId = null): ArrayDriver
+    {
+        Config::set('waitlist.mailing_list.enabled', true);
+        Config::set('waitlist.mailing_list.default', 'array');
+        Config::set('waitlist.mailing_list.queue.enabled', false);
+
+        if ($listId !== null || blank(config('waitlist.mailing_list.drivers.array.list_id'))) {
+            Config::set('waitlist.mailing_list.drivers.array.list_id', $listId ?? 'fake-list');
+        }
+
+        return $this->drivers['array'] = new ArrayDriver();
+    }
+
+    private function resolve(string $name): MailingListDriver
+    {
+        /** @var array<string, mixed> $config */
+        $config = config("waitlist.mailing_list.drivers.{$name}", []);
+
+        if (isset($this->customCreators[$name])) {
+            return ($this->customCreators[$name])($config);
+        }
+
+        return match ($name) {
+            'mailchimp' => $this->createMailchimpDriver($config),
+            'kit' => $this->createKitDriver($config),
+            'log' => new LogDriver(isset($config['channel']) ? (string) $config['channel'] : null),
+            'array' => new ArrayDriver(),
+            default => throw MailingListException::driverNotSupported($name),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function createMailchimpDriver(array $config): MailchimpDriver
+    {
+        if (blank($config['key'] ?? null)) {
+            throw MailingListException::missingCredentials('mailchimp', 'key');
+        }
+
+        return new MailchimpDriver(
+            key: (string) $config['key'],
+            server: filled($config['server'] ?? null) ? (string) $config['server'] : null,
+            timeout: $this->timeout($config),
+            retries: $this->retries($config),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function createKitDriver(array $config): KitDriver
+    {
+        if (blank($config['key'] ?? null)) {
+            throw MailingListException::missingCredentials('kit', 'key');
+        }
+
+        return new KitDriver(
+            key: (string) $config['key'],
+            listType: (string) ($config['list_type'] ?? 'form'),
+            timeout: $this->timeout($config),
+            retries: $this->retries($config),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function timeout(array $config): int
+    {
+        return (int) ($config['timeout'] ?? config('waitlist.mailing_list.timeout', 10));
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function retries(array $config): int
+    {
+        return (int) ($config['retries'] ?? config('waitlist.mailing_list.retries', 2));
+    }
+}

--- a/src/MailingList/Subscriber.php
+++ b/src/MailingList/Subscriber.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList;
+
+/**
+ * A subscriber as it exists on the remote mailing list service.
+ */
+final readonly class Subscriber
+{
+    /**
+     * @param  array<string, mixed>  $raw  The untouched payload returned by the provider.
+     */
+    public function __construct(
+        public string $id,
+        public string $email,
+        public ?string $status = null,
+        public array $raw = [],
+    ) {}
+}

--- a/src/Models/Waitlist.php
+++ b/src/Models/Waitlist.php
@@ -7,6 +7,7 @@ namespace OffloadProject\Waitlist\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
+use OffloadProject\Waitlist\Events\WaitlistCreated;
 
 /**
  * @property int $id
@@ -35,6 +36,11 @@ final class Waitlist extends Model
         'settings' => 'array',
     ];
 
+    /** @var array<string, class-string> */
+    protected $dispatchesEvents = [
+        'created' => WaitlistCreated::class,
+    ];
+
     /**
      * @return HasMany<WaitlistEntry, $this>
      */
@@ -60,5 +66,61 @@ final class Waitlist extends Model
         $this->update(['is_active' => false]);
 
         return $this;
+    }
+
+    /**
+     * The mailing list this waitlist syncs into, if one has been connected.
+     */
+    public function mailingListId(): ?string
+    {
+        $listId = $this->mailingListSetting('list_id');
+
+        return $listId === null ? null : (string) $listId;
+    }
+
+    /**
+     * The driver this waitlist syncs with, or null to use the configured default.
+     */
+    public function mailingListDriver(): ?string
+    {
+        $driver = $this->mailingListSetting('driver');
+
+        return $driver === null ? null : (string) $driver;
+    }
+
+    /**
+     * Point this waitlist at a list, audience, or form on a mailing list service.
+     */
+    public function connectMailingList(string $listId, ?string $driver = null): self
+    {
+        $this->update([
+            'settings' => array_merge($this->settings ?? [], [
+                'mailing_list' => array_filter([
+                    'list_id' => $listId,
+                    'driver' => $driver,
+                ], fn (?string $value): bool => $value !== null),
+            ]),
+        ]);
+
+        return $this;
+    }
+
+    public function disconnectMailingList(): self
+    {
+        $settings = $this->settings ?? [];
+
+        unset($settings['mailing_list']);
+
+        $this->update(['settings' => $settings]);
+
+        return $this;
+    }
+
+    private function mailingListSetting(string $key): mixed
+    {
+        /** @var array<string, mixed> $settings */
+        $settings = $this->settings['mailing_list'] ?? [];
+
+        return $settings[$key] ?? null;
     }
 }

--- a/src/Models/WaitlistEntry.php
+++ b/src/Models/WaitlistEntry.php
@@ -9,6 +9,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
 use OffloadProject\InviteOnly\Models\Invitation;
+use OffloadProject\Waitlist\Events\WaitlistEntryAdded;
+use OffloadProject\Waitlist\Events\WaitlistEntryInvited;
+use OffloadProject\Waitlist\Events\WaitlistEntryRejected;
+use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
 
 /**
  * @property int $id
@@ -21,6 +25,9 @@ use OffloadProject\InviteOnly\Models\Invitation;
  * @property string|null $verification_token
  * @property Carbon|null $verified_at
  * @property int|null $invitation_id
+ * @property string|null $mailing_list_driver
+ * @property string|null $mailing_list_subscriber_id
+ * @property Carbon|null $mailing_list_synced_at
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
@@ -39,6 +46,9 @@ final class WaitlistEntry extends Model
         'verification_token',
         'verified_at',
         'invitation_id',
+        'mailing_list_driver',
+        'mailing_list_subscriber_id',
+        'mailing_list_synced_at',
     ];
 
     /** @var array<string, string> */
@@ -46,6 +56,12 @@ final class WaitlistEntry extends Model
         'metadata' => 'array',
         'invited_at' => 'datetime',
         'verified_at' => 'datetime',
+        'mailing_list_synced_at' => 'datetime',
+    ];
+
+    /** @var array<string, class-string> */
+    protected $dispatchesEvents = [
+        'created' => WaitlistEntryAdded::class,
     ];
 
     /**
@@ -86,6 +102,8 @@ final class WaitlistEntry extends Model
             'invited_at' => now(),
         ]);
 
+        event(new WaitlistEntryInvited($this));
+
         return $this;
     }
 
@@ -94,6 +112,8 @@ final class WaitlistEntry extends Model
         $this->update([
             'status' => 'rejected',
         ]);
+
+        event(new WaitlistEntryRejected($this));
 
         return $this;
     }
@@ -115,6 +135,8 @@ final class WaitlistEntry extends Model
             'verification_token' => null,
         ]);
 
+        event(new WaitlistEntryVerified($this));
+
         return $this;
     }
 
@@ -122,6 +144,32 @@ final class WaitlistEntry extends Model
     {
         $this->update([
             'verification_token' => bin2hex(random_bytes(32)),
+        ]);
+
+        return $this;
+    }
+
+    public function isSubscribedToMailingList(): bool
+    {
+        return $this->mailing_list_synced_at !== null;
+    }
+
+    public function markAsSubscribed(string $driver, string $subscriberId): self
+    {
+        $this->update([
+            'mailing_list_driver' => $driver,
+            'mailing_list_subscriber_id' => $subscriberId,
+            'mailing_list_synced_at' => now(),
+        ]);
+
+        return $this;
+    }
+
+    public function markAsUnsubscribed(): self
+    {
+        $this->update([
+            'mailing_list_subscriber_id' => null,
+            'mailing_list_synced_at' => null,
         ]);
 
         return $this;

--- a/src/WaitlistService.php
+++ b/src/WaitlistService.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use OffloadProject\InviteOnly\Facades\InviteOnly;
 use OffloadProject\Waitlist\Exceptions\UnverifiedEntryException;
+use OffloadProject\Waitlist\Jobs\SyncEntryToMailingList;
+use OffloadProject\Waitlist\Jobs\UnsubscribeEntryFromMailingList;
 use OffloadProject\Waitlist\Models\Waitlist;
 use OffloadProject\Waitlist\Models\WaitlistEntry;
 
@@ -217,6 +219,73 @@ final class WaitlistService
         return $this->query()
             ->where('status', 'invited')
             ->count();
+    }
+
+    /**
+     * Point the current waitlist at a list, audience, or form on a mailing
+     * list service. Entries added to it sync there from then on.
+     */
+    public function connectMailingList(string $listId, ?string $driver = null): Waitlist
+    {
+        $waitlist = $this->currentWaitlist ?? $this->getDefault();
+
+        return $waitlist->connectMailingList($listId, $driver);
+    }
+
+    public function disconnectMailingList(): Waitlist
+    {
+        $waitlist = $this->currentWaitlist ?? $this->getDefault();
+
+        return $waitlist->disconnectMailingList();
+    }
+
+    public function subscribeToMailingList(int|WaitlistEntry $entry): WaitlistEntry
+    {
+        $entry = $this->resolveEntry($entry);
+
+        SyncEntryToMailingList::dispatchFor($entry);
+
+        return $entry;
+    }
+
+    public function unsubscribeFromMailingList(int|WaitlistEntry $entry): WaitlistEntry
+    {
+        $entry = $this->resolveEntry($entry);
+
+        UnsubscribeEntryFromMailingList::dispatchFor($entry);
+
+        return $entry;
+    }
+
+    /**
+     * Push entries of the current waitlist to its mailing list, skipping the
+     * ones already synced unless $force is passed.
+     *
+     * @return int The number of entries queued for syncing.
+     */
+    public function syncMailingList(bool $force = false): int
+    {
+        $query = $this->query();
+
+        if (! $force) {
+            $query->whereNull('mailing_list_synced_at');
+        }
+
+        // Unverified addresses have not opted in yet.
+        if (config('waitlist.verification.enabled', false)) {
+            $query->whereNotNull('verified_at');
+        }
+
+        $count = 0;
+
+        $query->chunkById(200, function (Collection $entries) use (&$count): void {
+            foreach ($entries as $entry) {
+                SyncEntryToMailingList::dispatchFor($entry);
+                $count++;
+            }
+        });
+
+        return $count;
     }
 
     private function requiresVerificationBeforeInvite(): bool

--- a/src/WaitlistServiceProvider.php
+++ b/src/WaitlistServiceProvider.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace OffloadProject\Waitlist;
 
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use OffloadProject\Waitlist\Console\SyncMailingListCommand;
+use OffloadProject\Waitlist\Events\WaitlistEntryAdded;
+use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
+use OffloadProject\Waitlist\Listeners\SubscribeEntryToMailingList;
+use OffloadProject\Waitlist\MailingList\MailingListManager;
 
 final class WaitlistServiceProvider extends ServiceProvider
 {
@@ -19,13 +25,26 @@ final class WaitlistServiceProvider extends ServiceProvider
         $this->app->singleton('waitlist', function ($app) {
             return new WaitlistService();
         });
+
+        $this->app->alias('waitlist', WaitlistService::class);
+
+        $this->app->singleton(MailingListManager::class, function ($app) {
+            return new MailingListManager();
+        });
+
+        $this->app->alias(MailingListManager::class, 'waitlist.mailing-list');
     }
 
     public function boot(): void
     {
         $this->registerRoutes();
+        $this->registerListeners();
 
         if ($this->app->runningInConsole()) {
+            $this->commands([
+                SyncMailingListCommand::class,
+            ]);
+
             $this->publishes([
                 __DIR__.'/../config/waitlist.php' => config_path('waitlist.php'),
             ], 'waitlist-config');
@@ -48,5 +67,11 @@ final class WaitlistServiceProvider extends ServiceProvider
         ], function () {
             $this->loadRoutesFrom(__DIR__.'/routes/waitlist.php');
         });
+    }
+
+    private function registerListeners(): void
+    {
+        Event::listen(WaitlistEntryAdded::class, SubscribeEntryToMailingList::class);
+        Event::listen(WaitlistEntryVerified::class, SubscribeEntryToMailingList::class);
     }
 }

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use OffloadProject\Waitlist\Events\WaitlistCreated;
+use OffloadProject\Waitlist\Events\WaitlistEntryAdded;
+use OffloadProject\Waitlist\Events\WaitlistEntryInvited;
+use OffloadProject\Waitlist\Events\WaitlistEntryRejected;
+use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
+use OffloadProject\Waitlist\Facades\Waitlist;
+
+test('creating a waitlist fires an event', function () {
+    Event::fake([WaitlistCreated::class]);
+
+    $beta = Waitlist::create('Beta', 'beta');
+
+    Event::assertDispatched(WaitlistCreated::class, fn (WaitlistCreated $event) => $event->waitlist->is($beta));
+});
+
+test('adding an entry fires an event', function () {
+    Event::fake([WaitlistEntryAdded::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Event::assertDispatched(WaitlistEntryAdded::class, fn (WaitlistEntryAdded $event) => $event->entry->is($entry));
+});
+
+test('verifying an entry fires an event', function () {
+    Event::fake([WaitlistEntryVerified::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    $entry->generateVerificationToken();
+
+    Waitlist::verify($entry->verification_token);
+
+    Event::assertDispatched(WaitlistEntryVerified::class, fn (WaitlistEntryVerified $event) => $event->entry->is($entry));
+});
+
+test('inviting an entry fires an event', function () {
+    Notification::fake();
+    Event::fake([WaitlistEntryInvited::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::invite($entry);
+
+    Event::assertDispatched(WaitlistEntryInvited::class, fn (WaitlistEntryInvited $event) => $event->entry->is($entry));
+});
+
+test('rejecting an entry fires an event', function () {
+    Event::fake([WaitlistEntryRejected::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::reject($entry);
+
+    Event::assertDispatched(WaitlistEntryRejected::class, fn (WaitlistEntryRejected $event) => $event->entry->is($entry));
+});

--- a/tests/Feature/MailingListTest.php
+++ b/tests/Feature/MailingListTest.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Events\MailingListSyncFailed;
+use OffloadProject\Waitlist\Events\WaitlistEntrySubscribed;
+use OffloadProject\Waitlist\Events\WaitlistEntryUnsubscribed;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\Facades\MailingList;
+use OffloadProject\Waitlist\Facades\Waitlist;
+use OffloadProject\Waitlist\Jobs\SyncEntryToMailingList;
+use OffloadProject\Waitlist\MailingList\Drivers\ArrayDriver;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+// Automatic syncing
+
+test('entries are not synced while the integration is disabled', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.enabled' => false]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    expect($fake->subscribers())->toBeEmpty();
+});
+
+test('adding an entry subscribes it to the mailing list', function () {
+    $fake = MailingList::fake('fake-list');
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    expect($fake->hasSubscriber('john@example.com', 'fake-list'))->toBeTrue()
+        ->and($entry->fresh()->mailing_list_driver)->toBe('array')
+        ->and($entry->fresh()->mailing_list_subscriber_id)->toBe(md5('john@example.com'))
+        ->and($entry->fresh()->isSubscribedToMailingList())->toBeTrue();
+});
+
+test('a subscribed entry fires an event', function () {
+    MailingList::fake();
+    Event::fake([WaitlistEntrySubscribed::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Event::assertDispatched(
+        WaitlistEntrySubscribed::class,
+        fn (WaitlistEntrySubscribed $event) => $event->entry->is($entry)
+            && $event->driver === 'array'
+            && $event->subscriber instanceof Subscriber
+    );
+});
+
+test('with verification enabled the entry only syncs once verified', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.verification.enabled' => true]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    expect($fake->hasSubscriber('john@example.com'))->toBeFalse();
+
+    Waitlist::verify($entry->fresh()->verification_token);
+
+    expect($fake->hasSubscriber('john@example.com'))->toBeTrue();
+});
+
+test('auto subscribing can be turned off', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    expect($fake->subscribers())->toBeEmpty();
+});
+
+test('syncing is queued by default', function () {
+    Queue::fake();
+    MailingList::fake();
+    config(['waitlist.mailing_list.queue.enabled' => true]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Queue::assertPushed(SyncEntryToMailingList::class);
+});
+
+// Per waitlist lists
+
+test('each waitlist can point at its own list', function () {
+    $fake = MailingList::fake();
+
+    Waitlist::create('Beta', 'beta');
+    Waitlist::create('Launch', 'launch');
+
+    Waitlist::for('beta')->connectMailingList('beta-audience');
+    Waitlist::for('launch')->connectMailingList('launch-audience');
+
+    Waitlist::for('beta')->add('John Doe', 'john@example.com');
+    Waitlist::for('launch')->add('Jane Doe', 'jane@example.com');
+
+    expect($fake->hasSubscriber('john@example.com', 'beta-audience'))->toBeTrue()
+        ->and($fake->hasSubscriber('jane@example.com', 'launch-audience'))->toBeTrue()
+        ->and($fake->hasSubscriber('jane@example.com', 'beta-audience'))->toBeFalse();
+});
+
+test('a waitlist can override the driver', function () {
+    MailingList::fake();
+
+    $beta = Waitlist::create('Beta', 'beta');
+    Waitlist::for('beta')->connectMailingList('beta-audience', 'mailchimp');
+
+    expect(MailingList::driverNameFor($beta->fresh()))->toBe('mailchimp')
+        ->and(MailingList::listIdFor($beta->fresh()))->toBe('beta-audience');
+});
+
+test('a waitlist falls back to the configured default list', function () {
+    MailingList::fake('default-list');
+
+    $beta = Waitlist::create('Beta', 'beta');
+
+    expect(MailingList::listIdFor($beta))->toBe('default-list');
+});
+
+test('a waitlist can be disconnected', function () {
+    MailingList::fake();
+
+    Waitlist::create('Beta', 'beta');
+    Waitlist::for('beta')->connectMailingList('beta-audience');
+    $beta = Waitlist::for('beta')->disconnectMailingList();
+
+    expect($beta->fresh()->mailingListId())->toBeNull();
+});
+
+test('a missing list id reports a failure instead of retrying forever', function () {
+    MailingList::fake();
+    config(['waitlist.mailing_list.drivers.array.list_id' => null]);
+    Event::fake([MailingListSyncFailed::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    expect($entry->fresh()->isSubscribedToMailingList())->toBeFalse();
+
+    Event::assertDispatched(
+        MailingListSyncFailed::class,
+        fn (MailingListSyncFailed $event) => $event->exception instanceof MailingListException
+    );
+});
+
+// Manual syncing
+
+test('an entry can be subscribed and unsubscribed by hand', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Waitlist::subscribeToMailingList($entry);
+    expect($fake->hasSubscriber('john@example.com'))->toBeTrue();
+
+    Event::fake([WaitlistEntryUnsubscribed::class]);
+    Waitlist::unsubscribeFromMailingList($entry);
+
+    expect($fake->hasSubscriber('john@example.com'))->toBeFalse()
+        ->and($entry->fresh()->isSubscribedToMailingList())->toBeFalse();
+
+    Event::assertDispatched(WaitlistEntryUnsubscribed::class);
+});
+
+test('existing entries can be backfilled', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Waitlist::add('User 1', 'user1@example.com');
+    Waitlist::add('User 2', 'user2@example.com');
+
+    expect(Waitlist::syncMailingList())->toBe(2)
+        ->and($fake->subscribers())->toHaveCount(2);
+
+    // Already synced entries are skipped on the next run.
+    expect(Waitlist::syncMailingList())->toBe(0)
+        ->and(Waitlist::syncMailingList(force: true))->toBe(2);
+});
+
+test('backfilling skips unverified entries when verification is enabled', function () {
+    $fake = MailingList::fake();
+    config([
+        'waitlist.mailing_list.auto_subscribe' => false,
+        'waitlist.verification.enabled' => true,
+    ]);
+
+    $verified = Waitlist::add('User 1', 'user1@example.com');
+    Waitlist::add('User 2', 'user2@example.com');
+
+    Waitlist::verify($verified->fresh()->verification_token);
+
+    expect(Waitlist::syncMailingList())->toBe(1)
+        ->and($fake->hasSubscriber('user1@example.com'))->toBeTrue()
+        ->and($fake->hasSubscriber('user2@example.com'))->toBeFalse();
+});
+
+test('the sync command queues entries for every waitlist', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Waitlist::create('Beta', 'beta');
+    Waitlist::for('beta')->connectMailingList('beta-audience');
+    Waitlist::for('beta')->add('John Doe', 'john@example.com');
+
+    $this->artisan('waitlist:sync-mailing-list', ['--all' => true])
+        ->assertSuccessful();
+
+    expect($fake->hasSubscriber('john@example.com', 'beta-audience'))->toBeTrue();
+});
+
+test('the sync command stops when the integration is disabled', function () {
+    config(['waitlist.mailing_list.enabled' => false]);
+
+    $this->artisan('waitlist:sync-mailing-list')->assertFailed();
+});
+
+// Drivers
+
+test('the mailchimp driver upserts a member on the audience', function () {
+    useDriver('mailchimp', [
+        'key' => 'secret-us14',
+        'list_id' => 'audience123',
+    ]);
+
+    Http::fake([
+        '*' => Http::response([
+            'id' => 'subscriber-hash',
+            'email_address' => 'john@example.com',
+            'status' => 'subscribed',
+        ]),
+    ]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request) {
+        return $request->method() === 'PUT'
+            && $request->url() === 'https://us14.api.mailchimp.com/3.0/lists/audience123/members/'.md5('john@example.com')
+            && $request['email_address'] === 'john@example.com'
+            && $request['status_if_new'] === 'subscribed'
+            && $request['merge_fields'] === ['FNAME' => 'John', 'LNAME' => 'Doe'];
+    });
+
+    expect($entry->fresh()->mailing_list_subscriber_id)->toBe('subscriber-hash');
+});
+
+test('the mailchimp driver sends pending members when double opt-in is on', function () {
+    useDriver('mailchimp', ['key' => 'secret-us14', 'list_id' => 'audience123']);
+    config(['waitlist.mailing_list.double_optin' => true]);
+
+    Http::fake(['*' => Http::response(['id' => 'hash', 'email_address' => 'john@example.com'])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request) => $request['status_if_new'] === 'pending');
+});
+
+test('the mailchimp driver applies configured tags', function () {
+    useDriver('mailchimp', ['key' => 'secret-us14', 'list_id' => 'audience123']);
+    config(['waitlist.mailing_list.tags' => ['waitlist']]);
+
+    Http::fake(['*' => Http::response(['id' => 'hash', 'email_address' => 'john@example.com'])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request) {
+        return str_ends_with($request->url(), '/tags')
+            && $request['tags'] === [['name' => 'waitlist', 'status' => 'active']];
+    });
+});
+
+test('the mailchimp driver derives the data centre from the api key', function () {
+    useDriver('mailchimp', ['key' => 'secret-us20', 'list_id' => 'audience123']);
+
+    Http::fake(['*' => Http::response(['id' => 'hash', 'email_address' => 'john@example.com'])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request) => str_starts_with($request->url(), 'https://us20.api.mailchimp.com/3.0/'));
+});
+
+test('a failing mailchimp request raises a mailing list exception', function () {
+    useDriver('mailchimp', ['key' => 'secret-us14', 'list_id' => 'audience123']);
+
+    Http::fake(['*' => Http::response(['detail' => 'Invalid resource'], 400)]);
+
+    expect(fn () => Waitlist::add('John Doe', 'john@example.com'))
+        ->toThrow(MailingListException::class, 'Invalid resource');
+});
+
+test('the kit driver creates the subscriber and adds them to the form', function () {
+    useDriver('kit', ['key' => 'kit-key', 'list_id' => 'form123']);
+
+    Http::fake([
+        'api.kit.com/v4/subscribers' => Http::response([
+            'subscriber' => ['id' => 42, 'email_address' => 'john@example.com', 'state' => 'active'],
+        ]),
+        'api.kit.com/v4/forms/*' => Http::response(['subscriber' => ['id' => 42]]),
+    ]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.kit.com/v4/subscribers'
+            && $request->hasHeader('X-Kit-Api-Key', 'kit-key')
+            && $request['email_address'] === 'john@example.com'
+            && $request['first_name'] === 'John';
+    });
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.kit.com/v4/forms/form123/subscribers');
+
+    expect($entry->fresh()->mailing_list_subscriber_id)->toBe('42');
+});
+
+test('the kit driver can treat the list id as a tag', function () {
+    useDriver('kit', ['key' => 'kit-key', 'list_id' => 'tag99', 'list_type' => 'tag']);
+
+    Http::fake(['*' => Http::response(['subscriber' => ['id' => 7, 'email_address' => 'john@example.com']])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.kit.com/v4/tags/tag99/subscribers');
+});
+
+test('the log driver never touches the network', function () {
+    useDriver('log', ['list_id' => 'log']);
+
+    Http::fake();
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertNothingSent();
+
+    expect($entry->fresh()->mailing_list_driver)->toBe('log');
+});
+
+test('custom drivers can be registered', function () {
+    config([
+        'waitlist.mailing_list.enabled' => true,
+        'waitlist.mailing_list.default' => 'custom',
+        'waitlist.mailing_list.queue.enabled' => false,
+        'waitlist.mailing_list.drivers.custom' => ['list_id' => 'custom-list'],
+    ]);
+
+    MailingList::extend('custom', fn (array $config) => new class implements MailingListDriver
+    {
+        public function name(): string
+        {
+            return 'custom';
+        }
+
+        public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+        {
+            return new Subscriber(id: 'custom-1', email: $entry->email);
+        }
+
+        public function unsubscribe(WaitlistEntry $entry, string $listId): void {}
+
+        public function tag(WaitlistEntry $entry, string $listId, array $tags): void {}
+
+        public function find(string $email, string $listId): ?Subscriber
+        {
+            return null;
+        }
+    });
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    expect($entry->fresh()->mailing_list_driver)->toBe('custom')
+        ->and($entry->fresh()->mailing_list_subscriber_id)->toBe('custom-1');
+});
+
+test('an unknown driver is rejected', function () {
+    config(['waitlist.mailing_list.default' => 'nope']);
+
+    expect(fn () => MailingList::driver())->toThrow(MailingListException::class, 'not supported');
+});
+
+test('the fake driver records the tags a real driver would apply', function () {
+    $fake = MailingList::fake();
+    config(['waitlist.mailing_list.tags' => ['beta']]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    MailingList::tagEntry($entry, ['invited']);
+
+    expect($fake)->toBeInstanceOf(ArrayDriver::class)
+        ->and($fake->tagsFor('john@example.com', 'fake-list'))->toBe(['beta', 'invited']);
+});
+
+/**
+ * Point the integration at a real driver, running syncs inline.
+ *
+ * @param  array<string, mixed>  $config
+ */
+function useDriver(string $driver, array $config): void
+{
+    config([
+        'waitlist.mailing_list.enabled' => true,
+        'waitlist.mailing_list.default' => $driver,
+        'waitlist.mailing_list.queue.enabled' => false,
+        "waitlist.mailing_list.drivers.{$driver}" => $config,
+    ]);
+}


### PR DESCRIPTION
# Description

  Adds an optional mailing list integration so waitlist entries flow into a newsletter service (Mailchimp or Kit) without
  the host app wiring up its own listeners and API calls.

  A waitlist is pointed at a list once:

  ```php
  Waitlist::for('beta')->connectMailingList('audience-id');
  ```

  From then on entries subscribe themselves — on sign up, or, when email verification is enabled, once the address has
  been confirmed. Syncing runs through a queued job so a sign up never waits on a third party API.

  The integration is off by default (`waitlist.mailing_list.enabled`), so nothing changes for existing installs until it
  is switched on.

  **What's included**
  
  - **Driver layer** — a `MailingListDriver` contract with `mailchimp`, `kit`, `log`, and `array` drivers, resolved
    through `MailingListManager` (a `MailingList` facade fronts it). `MailingList::extend()` registers a driver of your
    own.
  - **Per-waitlist configuration** — `connectMailingList()` / `disconnectMailingList()` store the list id (and an optional
    driver override) in the waitlist's `settings`, so several waitlists can sync to different audiences. Falls back to the
    driver's configured `list_id`.
  - **Events** — this change also introduces the event set the integration hangs off: `WaitlistCreated`,
    `WaitlistEntryAdded`, `WaitlistEntryVerified`, `WaitlistEntryInvited`, `WaitlistEntryRejected`, plus
    `WaitlistEntrySubscribed`, `WaitlistEntryUnsubscribed`, and `MailingListSyncFailed`. Useful on their own for host apps
    that want to react to waitlist activity.
  - **Backfill** — `waitlist:sync-mailing-list {waitlist?} {--all} {--force}` and `Waitlist::syncMailingList()` push
    existing entries, skipping ones already synced and (with verification on) ones not yet verified.
  - **Manual control** — `Waitlist::subscribeToMailingList($entry)` / `unsubscribeFromMailingList($entry)` for apps that
    turn `auto_subscribe` off.
  - **Testing helper** — `MailingList::fake()` swaps in the in-memory driver and runs syncs inline, so tests can assert on
    subscribers and tags with no HTTP faking.
  - **Failure handling** — API failures fire `MailingListSyncFailed` and retry with backoff; a missing list id is treated
    as a configuration error, reported once, and not retried.

  **Migration**: adds `mailing_list_driver`, `mailing_list_subscriber_id`, and `mailing_list_synced_at` to
  `waitlist_entries` (all nullable, plus an index on `mailing_list_synced_at`). Existing installs need to republish
  migrations (`--tag=waitlist-migrations`) and run them before enabling the feature.

  **Config note**: `waitlist.mailing_list.attributes` accepts a closure for mapping entries to provider fields. A config
  file containing a closure cannot be cached with `php artisan config:cache` — this is called out in the config comments
  and the README.

  No new package dependencies; both HTTP drivers use Laravel's HTTP client.

  Fixes # (issue)

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Deprecation (marks existing API as deprecated)
  - [ ] Refactor / internal change (no functional impact)
  - [x] Documentation update
  - [ ] CI / tooling change

  ## How Has This Been Tested?

  32 new Pest tests across `tests/Feature/MailingListTest.php` and `tests/Feature/EventsTest.php`, covering:

  - auto-subscribe on add, and deferral to verification when verification is enabled
  - the disabled and `auto_subscribe => false` paths staying inert
  - queued vs. inline dispatch, and `afterCommit` behaviour
  - per-waitlist list ids, driver overrides, default fallback, and disconnecting
  - the Mailchimp driver (upsert, double opt-in `pending` status, tags, data centre derived from the key, failure → `MailingListException`)
  - the Kit driver (subscriber upsert then form/tag attach, `list_type => tag`)
  - the log driver making no network calls, and rejection of unknown drivers
  - custom driver registration via `MailingList::extend()`
  - the backfill command and `syncMailingList()`, including skipping unverified entries
  - a missing list id reporting a failure instead of retrying
  - all five lifecycle events firing

  HTTP drivers are tested against `Http::fake()`; no live API calls in the suite.

  To reproduce in a host app: publish and run the migrations, set `WAITLIST_MAILING_LIST_ENABLED=true` with
  `WAITLIST_MAILING_LIST_DRIVER=log`, add an entry, and check the log channel for the subscribe payload.

  - [x] `composer test` passes — 81 passed (147 assertions)
  - [x] `composer analyse` (PHPStan / Larastan) passes — no errors
  - [x] `composer pint` shows no formatting changes
  - [x] Added or updated tests covering the change

  **Test Configuration**:
  
  - PHP version(s): 8.4 locally; CI matrix covers 8.3, 8.4, 8.5
  - Laravel version(s): CI matrix covers 11.x, 12.x, 13.x (prefer-lowest and prefer-stable)
  - Database driver: SQLite (in-memory)

  ## Checklist
  
  - [x] My code follows the style guidelines of this project (Pint / PSR-12)
  - [x] I have performed a self-review of my code
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing tests pass locally with my changes
  - [x] I have updated the README / docs where relevant
  - [x] My commit messages follow Conventional Commits
  - [x] Any breaking changes are clearly called out above
