### PR TITLE
feat: add audienceful integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ implement your own controllers, views, and API endpoints.
 - **Status tracking** — Pending, invited, and rejected states
 - **Email verification** — Optional opt-in verification before inviting users
 - **Event-driven notifications** — Automatic invite + verification notifications, fully customizable
-- **Mailing list sync** — Push entries to Mailchimp or Kit (ConvertKit), or plug in a driver of your own
+- **Mailing list sync** — Push entries to Mailchimp, Kit (ConvertKit) or Audienceful, or plug in a driver of your own
 - **Events** — Hook into every step of the lifecycle, from sign up to invite
 - **Metadata support** — Store custom data with each entry
 - **Invite-only integration** — Optional bridge into `offload-project/laravel-invite-only` for token-based flows
@@ -436,8 +436,8 @@ class CustomVerifyEmail extends Notification
 
 ### Mailing List Integration
 
-Sync entries into a newsletter service as they join. Mailchimp and Kit (ConvertKit) ship with the package, and you can
-register a driver for anything else.
+Sync entries into a newsletter service as they join. Mailchimp, Kit (ConvertKit) and Audienceful ship with the
+package, and you can register a driver for anything else.
 
 ```dotenv
 WAITLIST_MAILING_LIST_ENABLED=true
@@ -451,8 +451,9 @@ Then point a waitlist at a list — the id is whatever the provider calls it:
 ```php
 use OffloadProject\Waitlist\Facades\Waitlist;
 
-Waitlist::for('beta')->connectMailingList('a1b2c3d4e5');          // a Mailchimp audience
-Waitlist::for('launch')->connectMailingList('7654321', 'kit');    // a Kit form, on a different driver
+Waitlist::for('beta')->connectMailingList('a1b2c3d4e5');                    // a Mailchimp audience
+Waitlist::for('launch')->connectMailingList('7654321', 'kit');              // a Kit form, on a different driver
+Waitlist::for('early')->connectMailingList('kR2xN9mDfLpQ', 'audienceful');  // an Audienceful publication
 ```
 
 Each waitlist can sync into a different list, and into a different service. Waitlists that aren't connected fall back to
@@ -470,12 +471,13 @@ the provider's API.
 
 #### Drivers
 
-| Driver      | The list id is                                       | Notes                                                                     |
-|-------------|------------------------------------------------------|---------------------------------------------------------------------------|
-| `mailchimp` | an audience id                                       | Contacts are upserted, so an existing unsubscribe is never overridden       |
-| `kit`       | a form id, or a tag id with `list_type` set to `tag` | Kit unsubscribes are account-wide; double opt-in follows the form's setting |
-| `log`       | anything                                             | Writes what would have been sent to the log — handy for local work          |
-| `array`     | anything                                             | In-memory, used by `MailingList::fake()` in tests                           |
+| Driver         | The list id is                                            | Notes                                                                          |
+|----------------|-----------------------------------------------------------|--------------------------------------------------------------------------------|
+| `mailchimp`    | an audience id                                            | Contacts are upserted, so an existing unsubscribe is never overridden          |
+| `kit`          | a form id, or a tag id with `list_type` set to `tag`      | Kit unsubscribes are account-wide; double opt-in follows the form's setting    |
+| `audienceful`  | a publication id, or a tag name with `list_type` set to `tag` | Unsubscribing withdraws consent for that publication — or, for a tag, workspace wide |
+| `log`          | anything                                                  | Writes what would have been sent to the log — handy for local work             |
+| `array`        | anything                                                  | In-memory, used by `MailingList::fake()` in tests                              |
 
 #### Backfilling existing entries
 
@@ -507,7 +509,7 @@ MailingList::tagEntry($entry, ['beta-cohort']);
 
 #### Custom fields
 
-Map entry data onto Mailchimp merge fields or Kit custom fields:
+Map entry data onto Mailchimp merge fields, or Kit and Audienceful custom fields:
 
 ```php
 // config/waitlist.php
@@ -602,9 +604,9 @@ return [
     // Mailing list integration
     'mailing_list' => [
         'enabled' => false,  // Turn syncing on
-        'default' => 'log',  // mailchimp, kit, log, array — or your own
+        'default' => 'log',  // mailchimp, kit, audienceful, log, array — or your own
         'auto_subscribe' => true,  // Subscribe entries automatically
-        'double_optin' => false,  // Mailchimp only; Kit follows the form's setting
+        'double_optin' => false,  // Mailchimp and Audienceful; Kit follows the form's setting
         'tags' => [],  // Applied to every subscriber the package creates
         'attributes' => null,  // Closure mapping an entry to provider fields
         'queue' => [
@@ -624,6 +626,11 @@ return [
                 'key' => env('KIT_API_KEY'),
                 'list_type' => env('KIT_LIST_TYPE', 'form'),  // form or tag
                 'list_id' => env('KIT_FORM_ID'),
+            ],
+            'audienceful' => [
+                'key' => env('AUDIENCEFUL_API_KEY'),
+                'list_type' => env('AUDIENCEFUL_LIST_TYPE', 'publication'),  // publication or tag
+                'list_id' => env('AUDIENCEFUL_PUBLICATION_ID'),
             ],
         ],
     ],

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "launch",
     "mailchimp",
     "convertkit",
+    "audienceful",
     "newsletter",
     "offload-project"
   ],

--- a/config/waitlist.php
+++ b/config/waitlist.php
@@ -94,7 +94,8 @@ return [
     | Mailing List Integration
     |--------------------------------------------------------------------------
     |
-    | Push waitlist entries to a newsletter service such as Mailchimp or Kit.
+    | Push waitlist entries to a newsletter service such as Mailchimp, Kit
+    | or Audienceful.
     | Connect a waitlist to a list with:
     |
     |     Waitlist::for('beta')->connectMailingList('audience-id');
@@ -108,7 +109,7 @@ return [
 
         /*
         | The driver used by waitlists that have not picked one themselves.
-        | Ships with: mailchimp, kit, log, array.
+        | Ships with: mailchimp, kit, audienceful, log, array.
         */
         'default' => env('WAITLIST_MAILING_LIST_DRIVER', 'log'),
 
@@ -120,7 +121,8 @@ return [
 
         /*
         | Send new contacts a confirmation email before subscribing them.
-        | Mailchimp only — Kit uses the opt-in setting of the form itself.
+        | Honoured by Mailchimp and Audienceful — Kit uses the opt-in setting
+        | of the form itself.
         */
         'double_optin' => env('WAITLIST_MAILING_LIST_DOUBLE_OPTIN', false),
 
@@ -131,8 +133,8 @@ return [
 
         /*
         | A closure mapping an entry to provider fields (Mailchimp merge
-        | fields, Kit custom fields). Note that a config file containing a
-        | closure cannot be cached with `php artisan config:cache`.
+        | fields, Kit or Audienceful custom fields). Note that a config file
+        | containing a closure cannot be cached with `php artisan config:cache`.
         | Example: fn(WaitlistEntry $entry) => ['SOURCE' => $entry->metadata['source'] ?? null]
         */
         'attributes' => null,
@@ -167,6 +169,13 @@ return [
                 // Whether a list id refers to a Kit "form" or a "tag".
                 'list_type' => env('KIT_LIST_TYPE', 'form'),
                 'list_id' => env('KIT_FORM_ID'),
+            ],
+
+            'audienceful' => [
+                'key' => env('AUDIENCEFUL_API_KEY'),
+                // Whether a list id refers to an Audienceful "publication" or a "tag".
+                'list_type' => env('AUDIENCEFUL_LIST_TYPE', 'publication'),
+                'list_id' => env('AUDIENCEFUL_PUBLICATION_ID'),
             ],
 
             'log' => [

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Laravel Waitlist
-description: Conventions and APIs for the offload-project/laravel-waitlist package — multiple waitlists, entry status tracking, optional email verification, lifecycle events, mailing list sync (Mailchimp/Kit), and bridge into laravel-invite-only.
+description: Conventions and APIs for the offload-project/laravel-waitlist package — multiple waitlists, entry status tracking, optional email verification, lifecycle events, mailing list sync (Mailchimp/Kit/Audienceful), and bridge into laravel-invite-only.
 compatible_agents:
   - Claude Code
   - Cursor
@@ -13,6 +13,7 @@ tags:
   - invitations
   - mailing-list
   - mailchimp
+  - audienceful
 ---
 
 ## Context
@@ -25,7 +26,7 @@ tags:
 - Optional bridge into `offload-project/laravel-invite-only`: calling `Waitlist::invite()` creates a real `Invitation` (token, expiration, events) and persists the FK on `WaitlistEntry::$invitation_id`.
 - Two notifications: `WaitlistInvited` (opt-in via `auto_send_invitation`) and `VerifyWaitlistEmail`.
 - Lifecycle events in `OffloadProject\Waitlist\Events`: `WaitlistCreated`, `WaitlistEntryAdded`, `WaitlistEntryVerified`, `WaitlistEntryInvited`, `WaitlistEntryRejected`, plus `WaitlistEntrySubscribed`, `WaitlistEntryUnsubscribed`, and `MailingListSyncFailed`.
-- A mailing list integration (`MailingList` facade, `MailingListManager`) that syncs entries to Mailchimp or Kit (ConvertKit) in a queued job, with `log` and `array` drivers and an `extend()` hook for others.
+- A mailing list integration (`MailingList` facade, `MailingListManager`) that syncs entries to Mailchimp, Kit (ConvertKit) or Audienceful in a queued job, with `log` and `array` drivers and an `extend()` hook for others.
 - Typed exceptions: `UnverifiedEntryException` (invite attempted on an unverified entry while verification gating is on) and `MailingListException` (driver/credential/list-id/API failures).
 
 Apply this skill when working in a Laravel app that has `offload-project/laravel-waitlist` in `composer.json`, or when the user asks for help with `Waitlist`, `WaitlistEntry`, the `Waitlist` or `MailingList` facades, or waitlist flows in this package.
@@ -80,7 +81,7 @@ Apply this skill when working in a Laravel app that has `offload-project/laravel
 
 ### Mailing list sync
 
-23. Turn it on with `waitlist.mailing_list.enabled` and pick a driver (`mailchimp`, `kit`, `log`, `array`). Connect a waitlist to a list with `Waitlist::for($slug)->connectMailingList($listId, $driver = null)` — the list id is a Mailchimp audience id, or a Kit form id (or tag id when `list_type` is `tag`). Waitlists with no list of their own fall back to the driver's configured `list_id`.
+23. Turn it on with `waitlist.mailing_list.enabled` and pick a driver (`mailchimp`, `kit`, `audienceful`, `log`, `array`). Connect a waitlist to a list with `Waitlist::for($slug)->connectMailingList($listId, $driver = null)` — the list id is a Mailchimp audience id, a Kit form id (or tag id when `list_type` is `tag`), or an Audienceful publication id (or tag name when `list_type` is `tag`). Waitlists with no list of their own fall back to the driver's configured `list_id`.
 24. Don't build your own "subscribe on sign up" listener. Subscribing is automatic and follows the verification setting: with `waitlist.verification.enabled` off the entry syncs on `add()`, with it on the entry syncs after `Waitlist::verify()`. That ordering is deliberate — an unconfirmed address must never reach the newsletter.
 25. For anything beyond subscribing — tagging on invite, removing on reject, moving between lists — listen for the lifecycle events and call `MailingList::tagEntry($entry, [...])` or `Waitlist::unsubscribeFromMailingList($entry)`. Don't add those side effects inside the host app's controllers.
 26. Syncing runs through queued jobs (`SyncEntryToMailingList`, `UnsubscribeEntryFromMailingList`). Keep `mailing_list.queue.enabled` on in production so sign ups never block on the provider's API. Backfill existing rows with `php artisan waitlist:sync-mailing-list [slug] [--all] [--force]` or `Waitlist::for($slug)->syncMailingList()`.

--- a/src/MailingList/Drivers/AudiencefulDriver.php
+++ b/src/MailingList/Drivers/AudiencefulDriver.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Concerns\ResolvesEntryAttributes;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * Audienceful API v2.
+ *
+ * Contacts live on the workspace rather than on separate lists, so the list id
+ * is a publication id (default) — Audienceful's consent stream — or a tag name
+ * when the driver's `list_type` config is set to `tag`.
+ *
+ * Contacts are addressed by email in the request body rather than in the URL,
+ * and writes are additive: tags and publications are never removed by a call
+ * that does not name them.
+ *
+ * @see https://www.audienceful.com/help/api
+ */
+final class AudiencefulDriver implements MailingListDriver
+{
+    use ResolvesEntryAttributes;
+
+    public function __construct(
+        private readonly string $key,
+        private readonly string $listType = 'publication',
+        private readonly int $timeout = 10,
+        private readonly int $retries = 2,
+    ) {}
+
+    public function name(): string
+    {
+        return 'audienceful';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        $tags = $this->tags($options);
+
+        if ($this->tagsAreLists()) {
+            array_unshift($tags, $listId);
+        }
+
+        $payload = ['email' => $entry->email];
+
+        if ($tags !== []) {
+            $payload['tags'] = array_values(array_unique($tags));
+        }
+
+        $extraData = $this->extraData($entry, $options);
+
+        if ($extraData !== []) {
+            $payload['extra_data'] = $extraData;
+        }
+
+        // Only sent when opt-in is wanted, so the workspace's own setting
+        // stands — and a contact already part way through the flow is left
+        // where they are.
+        if ($this->wantsDoubleOptIn($options)) {
+            $payload['double_opt_in'] = 'required';
+        }
+
+        // Upserts: an email that already exists merges into that contact.
+        $response = $this->request()->post('/people', $payload);
+
+        $this->throwUnlessSuccessful($response);
+
+        if (! $this->tagsAreLists()) {
+            $this->consent($entry->email, $listId, true);
+        }
+
+        return $this->toSubscriber($response->json());
+    }
+
+    /**
+     * Withdraw consent for the publication, or — when lists are tags, which
+     * Audienceful cannot remove — unsubscribe the contact workspace wide.
+     */
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        if ($this->tagsAreLists()) {
+            $this->swallowingMissingContact(
+                $this->request()->post('/people/unsubscribe', ['email' => $entry->email])
+            );
+
+            return;
+        }
+
+        $this->consent($entry->email, $listId, false);
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        if ($tags === []) {
+            return;
+        }
+
+        // Tags are additive, so this adds to whatever the contact already has.
+        $this->throwUnlessSuccessful(
+            $this->request()->post('/people', [
+                'email' => $entry->email,
+                'tags' => $tags,
+            ])
+        );
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        // Filtering the collection rather than fetching /people/{email}, which
+        // would put the address in the URL.
+        $response = $this->request()->get('/people', ['email' => $email]);
+
+        $this->throwUnlessSuccessful($response);
+
+        /** @var array<int, array<string, mixed>> $people */
+        $people = $response->json('data', []);
+
+        if ($people === []) {
+            return null;
+        }
+
+        return $this->toSubscriber($people[0]);
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl('https://api.audienceful.com/v2')
+            ->withHeaders(['X-Api-Key' => $this->key])
+            ->timeout($this->timeout)
+            ->retry(max(1, $this->retries), 250, throw: false)
+            ->acceptJson();
+    }
+
+    private function tagsAreLists(): bool
+    {
+        return $this->listType === 'tag';
+    }
+
+    /**
+     * Grant or withdraw consent for a single publication. Only the ids named
+     * here are touched.
+     */
+    private function consent(string $email, string $publicationId, bool $subscribed): void
+    {
+        $this->swallowingMissingContact(
+            $this->request()->post('/people/publications', [
+                'email' => $email,
+                'publications' => [$publicationId => $subscribed],
+            ])
+        );
+    }
+
+    /**
+     * Audienceful has no first and last name of its own, so the entry's name
+     * lands in the `name` custom field alongside the mapped attributes.
+     *
+     * @param  array{attributes?: array<string, mixed>}  $options
+     * @return array<string, mixed>
+     */
+    private function extraData(WaitlistEntry $entry, array $options): array
+    {
+        return array_merge(['name' => $entry->name], $this->attributes($entry, $options));
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function toSubscriber(?array $payload): Subscriber
+    {
+        $payload ??= [];
+
+        return new Subscriber(
+            id: (string) ($payload['id'] ?? ''),
+            email: (string) ($payload['email'] ?? ''),
+            status: isset($payload['status']) ? (string) $payload['status'] : null,
+            raw: $payload,
+        );
+    }
+
+    /**
+     * A contact that was never synced is already in the desired state.
+     */
+    private function swallowingMissingContact(Response $response): void
+    {
+        if ($response->status() === 404) {
+            return;
+        }
+
+        $this->throwUnlessSuccessful($response);
+    }
+
+    private function throwUnlessSuccessful(Response $response): void
+    {
+        if ($response->successful()) {
+            return;
+        }
+
+        throw MailingListException::requestFailed(
+            'audienceful',
+            (string) ($response->json('error.message') ?? $response->body()),
+            $response->status(),
+        );
+    }
+}

--- a/src/MailingList/MailingListManager.php
+++ b/src/MailingList/MailingListManager.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use OffloadProject\Waitlist\Contracts\MailingListDriver;
 use OffloadProject\Waitlist\Exceptions\MailingListException;
 use OffloadProject\Waitlist\MailingList\Drivers\ArrayDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\AudiencefulDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\KitDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\LogDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\MailchimpDriver;
@@ -145,6 +146,7 @@ final class MailingListManager
         return match ($name) {
             'mailchimp' => $this->createMailchimpDriver($config),
             'kit' => $this->createKitDriver($config),
+            'audienceful' => $this->createAudiencefulDriver($config),
             'log' => new LogDriver(isset($config['channel']) ? (string) $config['channel'] : null),
             'array' => new ArrayDriver(),
             default => throw MailingListException::driverNotSupported($name),
@@ -180,6 +182,23 @@ final class MailingListManager
         return new KitDriver(
             key: (string) $config['key'],
             listType: (string) ($config['list_type'] ?? 'form'),
+            timeout: $this->timeout($config),
+            retries: $this->retries($config),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function createAudiencefulDriver(array $config): AudiencefulDriver
+    {
+        if (blank($config['key'] ?? null)) {
+            throw MailingListException::missingCredentials('audienceful', 'key');
+        }
+
+        return new AudiencefulDriver(
+            key: (string) $config['key'],
+            listType: (string) ($config['list_type'] ?? 'publication'),
             timeout: $this->timeout($config),
             retries: $this->retries($config),
         );

--- a/tests/Feature/MailingListTest.php
+++ b/tests/Feature/MailingListTest.php
@@ -326,6 +326,133 @@ test('the kit driver can treat the list id as a tag', function () {
     Http::assertSent(fn ($request) => $request->url() === 'https://api.kit.com/v4/tags/tag99/subscribers');
 });
 
+test('the audienceful driver upserts the contact and grants publication consent', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+
+    Http::fake([
+        'api.audienceful.com/v2/people' => Http::response([
+            'id' => 'jQKdwqp3YR',
+            'email' => 'john@example.com',
+            'status' => 'active',
+        ]),
+        'api.audienceful.com/v2/people/publications' => Http::response(['data' => []]),
+    ]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.audienceful.com/v2/people'
+            && $request->method() === 'POST'
+            && $request->hasHeader('X-Api-Key', 'af-key')
+            && $request['email'] === 'john@example.com'
+            && $request['extra_data'] === ['name' => 'John Doe']
+            && ! isset($request['double_opt_in']);
+    });
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.audienceful.com/v2/people/publications'
+            && $request['email'] === 'john@example.com'
+            && $request['publications'] === ['pub123' => true];
+    });
+
+    expect($entry->fresh()->mailing_list_subscriber_id)->toBe('jQKdwqp3YR');
+});
+
+test('the audienceful driver asks for double opt-in when it is on', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+    config(['waitlist.mailing_list.double_optin' => true]);
+
+    Http::fake(['*' => Http::response(['id' => 'p1', 'email' => 'john@example.com'])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.audienceful.com/v2/people'
+        && $request['double_opt_in'] === 'required');
+});
+
+test('the audienceful driver can treat the list id as a tag', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'beta', 'list_type' => 'tag']);
+    config(['waitlist.mailing_list.tags' => ['waitlist']]);
+
+    Http::fake(['*' => Http::response(['id' => 'p1', 'email' => 'john@example.com'])]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request) => $request['tags'] === ['beta', 'waitlist']);
+    Http::assertNotSent(fn ($request) => str_ends_with($request->url(), '/people/publications'));
+});
+
+test('the audienceful driver withdraws consent for the publication', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Http::fake(['*' => Http::response(['data' => []])]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::unsubscribeFromMailingList($entry);
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.audienceful.com/v2/people/publications'
+            && $request['publications'] === ['pub123' => false];
+    });
+});
+
+test('the audienceful driver unsubscribes workspace wide when lists are tags', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'beta', 'list_type' => 'tag']);
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Http::fake(['*' => Http::response([])]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+    Waitlist::unsubscribeFromMailingList($entry);
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://api.audienceful.com/v2/people/unsubscribe'
+        && $request['email'] === 'john@example.com');
+});
+
+test('unsubscribing an unknown audienceful contact is not an error', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Http::fake(['*' => Http::response(['error' => ['message' => 'Not found.']], 404)]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    expect(fn () => Waitlist::unsubscribeFromMailingList($entry))->not->toThrow(MailingListException::class);
+});
+
+test('the audienceful driver finds a contact by email', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+
+    Http::fake([
+        'api.audienceful.com/v2/people?email=jane*' => Http::response(['data' => []]),
+        'api.audienceful.com/v2/people*' => Http::response([
+            'data' => [['id' => 'p1', 'email' => 'john@example.com', 'status' => 'active']],
+            'has_more' => false,
+            'next_cursor' => null,
+        ]),
+    ]);
+
+    $driver = MailingList::driver('audienceful');
+
+    expect($driver->find('john@example.com', 'pub123'))
+        ->toBeInstanceOf(Subscriber::class)
+        ->id->toBe('p1')
+        ->status->toBe('active')
+        ->and($driver->find('jane@example.com', 'pub123'))->toBeNull();
+});
+
+test('a failing audienceful request raises a mailing list exception', function () {
+    useDriver('audienceful', ['key' => 'af-key', 'list_id' => 'pub123']);
+
+    Http::fake(['*' => Http::response([
+        'error' => ['type' => 'invalid_request_error', 'message' => 'Enter a valid email address.'],
+    ], 400)]);
+
+    expect(fn () => Waitlist::add('John Doe', 'john@example.com'))
+        ->toThrow(MailingListException::class, 'Enter a valid email address.');
+});
+
 test('the log driver never touches the network', function () {
     useDriver('log', ['list_id' => 'log']);
 


### PR DESCRIPTION
# Description

Adds an `audienceful` mailing list driver, so waitlist entries can sync into [Audienceful](https://www.audienceful.com/help/api) the same way they already sync into Mailchimp and Kit.

Built against the Audienceful **v2** API (`https://api.audienceful.com/v2`, `X-Api-Key` header). Endpoint shapes, the response envelope and the error envelope were verified against the published OpenAPI schema at `api.audienceful.com/v2/openapi.json` and against the live API.

`src/MailingList/Drivers/AudiencefulDriver.php` implements `MailingListDriver` following the same shape as `KitDriver`:

| Contract method | Request |
|---|---|
| `subscribe()`   | `POST /people` upserts by email (`tags`, `extra_data`, `double_opt_in`), then `POST /people/publications` grants consent for the list |
| `unsubscribe()` | `POST /people/publications` withdraws consent for that one publication — or a workspace-wide `POST /people/unsubscribe` in tag mode |
| `tag()`         | `POST /people` with `tags`, which Audienceful applies additively |
| `find()`        | `GET /people?email=` — the lookup the docs recommend, since it returns an empty `data` array instead of a 404 and keeps the address out of the URL |

Fixes # (issue)

### Decisions worth a reviewer's attention

- **The list id is a publication id by default**, with `list_type: 'tag'` as the alternative — mirroring Kit's existing `list_type` config. Audiences were the other candidate for "the list", but v2 exposes them read-only (list + members only), so they can't be a sync target. Publications are Audienceful's consent stream and the thing you actually subscribe someone to.
- **`double_opt_in` is only sent when opt-in is on** (as `'required'`), never as `'not_required'`. Omitting it leaves the workspace's own setting in charge and won't knock a contact out of a flow they are already part way through — the same reasoning behind `status_if_new` in the Mailchimp driver.
- **404s on unsubscribe are swallowed**, matching `MailchimpDriver`: a contact that was never synced is already in the desired state.
- **Tag-mode unsubscribe is workspace-wide.** The v2 API has no tag removal at all — tags are documented as additive-only, with no `remove_tags` or replace flag — so a global unsubscribe is the only honest way to stop emailing someone. This is the same tradeoff `KitDriver` already makes for account-wide unsubscribes, and it is called out in the README driver table.
- **`$entry->name` lands in the `name` custom field** via `extra_data`. Audienceful has no built-in name field, so there is no first/last split to mirror as there is for Mailchimp (`FNAME`/`LNAME`) and Kit (`first_name`).

### Configuration

```dotenv
WAITLIST_MAILING_LIST_ENABLED=true
WAITLIST_MAILING_LIST_DRIVER=audienceful

AUDIENCEFUL_API_KEY=...
AUDIENCEFUL_PUBLICATION_ID=kR2xN9mDfLpQ   # optional fallback list
AUDIENCEFUL_LIST_TYPE=publication         # or: tag
```

```php
Waitlist::for('early')->connectMailingList('kR2xN9mDfLpQ', 'audienceful');
```

The API key needs the `people:write` scope, plus `publications:write` when the list id is a publication.

### Files touched

- `src/MailingList/Drivers/AudiencefulDriver.php` — new driver
- `src/MailingList/MailingListManager.php` — resolve `audienceful`, with a `missingCredentials` guard on `key`
- `config/waitlist.php` — driver block and refreshed comments on `default`, `double_optin` and `attributes`
- `README.md`, `skills/SKILL.md`, `composer.json` keywords — docs

No changes to the `MailingListDriver` contract, the manager's public API, the models, or the schema. Existing drivers are untouched.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Deprecation (marks existing API as deprecated)
- [ ] Refactor / internal change (no functional impact)
- [x] Documentation update
- [ ] CI / tooling change

## How Has This Been Tested?

Eight new Pest tests in `tests/Feature/MailingListTest.php`, sitting with the other driver tests and using the existing `useDriver()` helper plus `Http::fake()` to assert the exact requests the driver sends:

- upserts the contact and grants publication consent (asserts URL, `X-Api-Key`, `extra_data`, and that `double_opt_in` is absent)
- sends `double_opt_in: required` when the option is on
- tag mode prepends the list id to the configured tags and skips the publications call entirely
- unsubscribe withdraws consent with `{"pub123": false}`
- tag-mode unsubscribe hits `/people/unsubscribe`
- a 404 on unsubscribe is not an error
- `find()` maps the `data` envelope to a `Subscriber`, and returns `null` on an empty result
- a failed request raises `MailingListException` carrying the `error.message` from the response

Reproduce with `vendor/bin/pest --filter=audienceful`. No network access is needed — every test is fully faked.

- [x] `composer test` passes — 89 passed (162 assertions)
- [x] `composer analyse` (PHPStan / Larastan) passes — no errors
- [x] `composer pint` shows no formatting changes
- [x] Added or updated tests covering the change

**Test Configuration**:

- PHP version(s): 8.4.24 locally; CI matrix covers 8.3, 8.4, 8.5
- Laravel version(s): CI matrix covers 11.x, 12.x, 13.x on both `prefer-lowest` and `prefer-stable`
- Database driver: SQLite (`:memory:`)

Not yet exercised against a live Audienceful workspace — the request shapes are asserted against the documented API rather than a real key, so a smoke test against a real workspace before release would be worthwhile.

## Checklist

- [x] My code follows the style guidelines of this project (Pint / PSR-12)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the README / docs where relevant
- [x] My commit messages follow Conventional Commits
- [x] Any breaking changes are clearly called out above — there are none
