### PR TITLE
fix: mailing list subscription integration logging

### DIFF
--- a/src/Listeners/SubscribeEntryToMailingList.php
+++ b/src/Listeners/SubscribeEntryToMailingList.php
@@ -4,19 +4,44 @@ declare(strict_types=1);
 
 namespace OffloadProject\Waitlist\Listeners;
 
+use Illuminate\Support\Facades\Log;
 use OffloadProject\Waitlist\Events\WaitlistEntryAdded;
 use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
 use OffloadProject\Waitlist\Jobs\SyncEntryToMailingList;
 
+/**
+ * Puts a new — or newly verified — entry on the mailing list.
+ *
+ * Every reason this decides *not* to sync is logged. A sync that never starts
+ * leaves no job, no failure and no event, so from the outside it is
+ * indistinguishable from one that succeeded: the entry simply never appears in
+ * the provider. Naming the config key that stopped it turns a silent
+ * misconfiguration into a line somebody can search for.
+ */
 final class SubscribeEntryToMailingList
 {
     public function handle(WaitlistEntryAdded|WaitlistEntryVerified $event): void
     {
+        $context = [
+            'entry_id' => $event->entry->getKey(),
+            'waitlist' => $event->entry->waitlist?->slug,
+        ];
+
         if (! config('waitlist.mailing_list.enabled', false)) {
+            Log::info(
+                'Waitlist entry not synced: the mailing list integration is off. Set waitlist.mailing_list.enabled to change this.',
+                $context,
+            );
+
             return;
         }
 
         if (! config('waitlist.mailing_list.auto_subscribe', true)) {
+            Log::info(
+                'Waitlist entry not synced: automatic subscribing is off. Set waitlist.mailing_list.auto_subscribe to change this, or sync it by hand with Waitlist::subscribe().',
+                $context,
+            );
+
             return;
         }
 
@@ -25,6 +50,20 @@ final class SubscribeEntryToMailingList
         // With verification turned on we hold off until the address is
         // confirmed; without it, we subscribe as soon as the entry is added.
         if ($awaitingVerification !== ($event instanceof WaitlistEntryVerified)) {
+            /*
+             * Only one side of this is worth a line. An unverified entry is
+             * waiting for something that may never happen, and that is the case
+             * people come looking for. The other side — a verification event
+             * arriving while verification is off — is a no-op by design,
+             * because the entry was already synced when it was added.
+             */
+            if ($awaitingVerification) {
+                Log::info(
+                    'Waitlist entry not synced yet: it is held until the email address is verified.',
+                    $context,
+                );
+            }
+
             return;
         }
 

--- a/tests/Feature/MailingListTest.php
+++ b/tests/Feature/MailingListTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
 use OffloadProject\Waitlist\Contracts\MailingListDriver;
 use OffloadProject\Waitlist\Events\MailingListSyncFailed;
 use OffloadProject\Waitlist\Events\WaitlistEntrySubscribed;
 use OffloadProject\Waitlist\Events\WaitlistEntryUnsubscribed;
+use OffloadProject\Waitlist\Events\WaitlistEntryVerified;
 use OffloadProject\Waitlist\Exceptions\MailingListException;
 use OffloadProject\Waitlist\Facades\MailingList;
 use OffloadProject\Waitlist\Facades\Waitlist;
@@ -26,6 +29,66 @@ test('entries are not synced while the integration is disabled', function () {
     Waitlist::add('John Doe', 'john@example.com');
 
     expect($fake->subscribers())->toBeEmpty();
+});
+
+test('it says why in the log when the integration is off', function () {
+    MailingList::fake();
+    config(['waitlist.mailing_list.enabled' => false]);
+
+    Log::shouldReceive('info')
+        ->once()
+        ->withArgs(fn (string $message): bool => str_contains($message, 'waitlist.mailing_list.enabled'));
+
+    Waitlist::add('John Doe', 'john@example.com');
+});
+
+test('it says why in the log when auto-subscribing is off', function () {
+    MailingList::fake();
+    config(['waitlist.mailing_list.auto_subscribe' => false]);
+
+    Log::shouldReceive('info')
+        ->once()
+        ->withArgs(fn (string $message): bool => str_contains($message, 'waitlist.mailing_list.auto_subscribe'));
+
+    Waitlist::add('John Doe', 'john@example.com');
+});
+
+/*
+ * The one people come looking for: the entry exists, nothing failed, and it is
+ * simply waiting for a click that may never come.
+ */
+test('it says why in the log while an entry waits to be verified', function () {
+    MailingList::fake();
+    config(['waitlist.verification.enabled' => true]);
+
+    // The verification email would otherwise go out through the log mail
+    // driver, which reaches for the very facade this test is mocking.
+    Notification::fake();
+
+    Log::shouldReceive('info')
+        ->once()
+        ->withArgs(fn (string $message): bool => str_contains($message, 'verified'));
+
+    Waitlist::add('John Doe', 'john@example.com');
+});
+
+/*
+ * A verification event with verification switched off is a no-op by design —
+ * the entry was synced when it was added — so it must not sync a second time,
+ * and must not report itself as a skipped sync either.
+ */
+test('a verification event does nothing when verification is off', function () {
+    MailingList::fake('fake-list');
+    config(['waitlist.verification.enabled' => false]);
+    Event::fake([WaitlistEntrySubscribed::class]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Event::assertDispatchedTimes(WaitlistEntrySubscribed::class, 1);
+
+    event(new WaitlistEntryVerified($entry));
+
+    Event::assertDispatchedTimes(WaitlistEntrySubscribed::class, 1);
 });
 
 test('adding an entry subscribes it to the mailing list', function () {

--- a/tests/Feature/MailingListTest.php
+++ b/tests/Feature/MailingListTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Queue;
 use OffloadProject\Waitlist\Contracts\MailingListDriver;
@@ -35,22 +34,22 @@ test('it says why in the log when the integration is off', function () {
     MailingList::fake();
     config(['waitlist.mailing_list.enabled' => false]);
 
-    Log::shouldReceive('info')
-        ->once()
-        ->withArgs(fn (string $message): bool => str_contains($message, 'waitlist.mailing_list.enabled'));
+    $log = capturedLog();
 
     Waitlist::add('John Doe', 'john@example.com');
+
+    expect($log)->toHaveLoggedOnce('waitlist.mailing_list.enabled');
 });
 
 test('it says why in the log when auto-subscribing is off', function () {
     MailingList::fake();
     config(['waitlist.mailing_list.auto_subscribe' => false]);
 
-    Log::shouldReceive('info')
-        ->once()
-        ->withArgs(fn (string $message): bool => str_contains($message, 'waitlist.mailing_list.auto_subscribe'));
+    $log = capturedLog();
 
     Waitlist::add('John Doe', 'john@example.com');
+
+    expect($log)->toHaveLoggedOnce('waitlist.mailing_list.auto_subscribe');
 });
 
 /*
@@ -61,15 +60,14 @@ test('it says why in the log while an entry waits to be verified', function () {
     MailingList::fake();
     config(['waitlist.verification.enabled' => true]);
 
-    // The verification email would otherwise go out through the log mail
-    // driver, which reaches for the very facade this test is mocking.
+    // Held back so the verification email cannot write a log line of its own.
     Notification::fake();
 
-    Log::shouldReceive('info')
-        ->once()
-        ->withArgs(fn (string $message): bool => str_contains($message, 'verified'));
+    $log = capturedLog();
 
     Waitlist::add('John Doe', 'john@example.com');
+
+    expect($log)->toHaveLoggedOnce('verified');
 });
 
 /*

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,46 @@
 
 declare(strict_types=1);
 
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Event;
 use OffloadProject\Waitlist\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
+
+/**
+ * Collects the messages written to the log from here to the end of the test.
+ *
+ * Mocking the Log facade would be shorter, but Laravel reports PHP deprecation
+ * notices through that same facade, and dependencies emit them on some of the
+ * PHP and package versions this suite runs against. A mock that only expects
+ * info() dies on the channel() call the reporter makes, which turns somebody
+ * else's deprecation into a failure here. Listening for the event the real
+ * logger fires keeps the two apart.
+ *
+ * @return ArrayObject<int, string>
+ */
+function capturedLog(): ArrayObject
+{
+    /** @var ArrayObject<int, string> $messages */
+    $messages = new ArrayObject;
+
+    Event::listen(MessageLogged::class, function (MessageLogged $logged) use ($messages): void {
+        $messages[] = $logged->message;
+    });
+
+    return $messages;
+}
+
+/*
+ * Asserts a captured log holds exactly one message mentioning the given text.
+ */
+expect()->extend('toHaveLoggedOnce', function (string $text) {
+    $matching = array_filter(
+        (array) $this->value,
+        fn (string $message): bool => str_contains($message, $text),
+    );
+
+    expect($matching)->toHaveCount(1);
+
+    return $this;
+});


### PR DESCRIPTION
# Description

## Why

  A sign-up in production never reached the mailing list provider, and there was nothing anywhere to say why. No queued job, no failed job, no exception, no log line —
  the entry simply sat there while the provider showed nothing. From the outside, a sync that never started looks exactly like one that succeeded.

  `SubscribeEntryToMailingList` has three early returns before it dispatches, and all three were silent. Two of them are ordinary misconfiguration:

  - `waitlist.mailing_list.enabled` is `false` — which is what `.env.example` ships, so an environment set up from the example has the provider fully configured and the
  integration switched off.
  - `waitlist.mailing_list.auto_subscribe` is `false`.

  The third is not a misconfiguration at all: with verification enabled, an entry is held until the address is confirmed. That is correct behaviour, and it is also the
  case people spend the longest looking for, because the entry exists, nothing failed, and it is waiting on a click that may never come.

## What changed                                                                                                                                                   

  Each of those paths now logs at `info`, naming the config key responsible so it can be searched for directly. Every line carries the entry id and the waitlist slug.
                                                                                                                                                                    
  Sign-ups are low-frequency, so `info` is proportionate — and `debug` would have been invisible in the environments where this actually bites.

## What deliberately stays silent

  The verification branch has two sides, and only one is worth reporting. A `WaitlistEntryVerified` event arriving while verification is switched *off* is a no-op by
  design: the entry was already synced when it was added. Logging that as a skipped sync would be wrong. There is a test pinning it, and it asserts the real contract —
  that no second `WaitlistEntrySubscribed` is dispatched — rather than the absence of a log line.


  A sign-up in production never reached the mailing list provider, and there was nothing anywhere to say why. No queued job, no failed job, no exception, no log line —
  the entry simply sat there while the provider showed nothing. From the outside, a sync that never started looks exactly like one that succeeded.

  `SubscribeEntryToMailingList` has three early returns before it dispatches, and all three were silent. Two of them are ordinary misconfiguration:

  - `waitlist.mailing_list.enabled` is `false` — which is what `.env.example` ships, so an environment set up from the example has the provider fully configured and the
  integration switched off.
  - `waitlist.mailing_list.auto_subscribe` is `false`.

  The third is not a misconfiguration at all: with verification enabled, an entry is held until the address is confirmed. That is correct behaviour, and it is also the
  case people spend the longest looking for, because the entry exists, nothing failed, and it is waiting on a click that may never come.

## What changed

  Each of those paths now logs at `info`, naming the config key responsible so it can be searched for directly. Every line carries the entry id and the waitlist slug.

  Sign-ups are low-frequency, so `info` is proportionate — and `debug` would have been invisible in the environments where this actually bites.

## What deliberately stays silent

  The verification branch has two sides, and only one is worth reporting. A `WaitlistEntryVerified` event arriving while verification is switched *off* is a no-op by
  design: the entry was already synced when it was added. Logging that as a skipped sync would be wrong. There is a test pinning it, and it asserts the real contract —
  that no second `WaitlistEntrySubscribed` is dispatched — rather than the absence of a log line.

## Behaviour

  None. Only `Log::info()` calls were added; every branch and every return is unchanged. No config, no signature, no event.

## Tests

  Four added to `MailingListTest`, covering each of the three logged reasons and the one that must stay quiet.

  One wrinkle worth knowing if these are edited later: with verification on, `Waitlist::add()` sends the verification notification, which goes out through the log mail
  driver and reaches for the very facade the test is mocking. That test fakes notifications for exactly that reason.

