### PR TITLE
feat: constant contact integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ implement your own controllers, views, and API endpoints.
 - **Status tracking** — Pending, invited, and rejected states
 - **Email verification** — Optional opt-in verification before inviting users
 - **Event-driven notifications** — Automatic invite + verification notifications, fully customizable
-- **Mailing list sync** — Push entries to Mailchimp, Kit (ConvertKit) or Audienceful, or plug in a driver of your own
+- **Mailing list sync** — Push entries to Mailchimp, Kit (ConvertKit), Audienceful or Constant Contact, or plug in a driver of your own
 - **Events** — Hook into every step of the lifecycle, from sign up to invite
 - **Metadata support** — Store custom data with each entry
 - **Invite-only integration** — Optional bridge into `offload-project/laravel-invite-only` for token-based flows
@@ -436,8 +436,8 @@ class CustomVerifyEmail extends Notification
 
 ### Mailing List Integration
 
-Sync entries into a newsletter service as they join. Mailchimp, Kit (ConvertKit) and Audienceful ship with the
-package, and you can register a driver for anything else.
+Sync entries into a newsletter service as they join. Mailchimp, Kit (ConvertKit), Audienceful and Constant Contact
+ship with the package, and you can register a driver for anything else.
 
 ```dotenv
 WAITLIST_MAILING_LIST_ENABLED=true
@@ -469,6 +469,22 @@ From there, entries subscribe themselves — and the timing follows your verific
 That way an unconfirmed address never reaches your newsletter. Syncing runs in a queued job, so sign ups never wait on
 the provider's API.
 
+##### Make sure something is reading the queue
+
+The sync is dispatched onto whatever `queue.connection` and `queue.queue` name, and **both fall back to the
+application's defaults when they are null**:
+
+```dotenv
+WAITLIST_MAILING_LIST_QUEUE_CONNECTION=redis
+WAITLIST_MAILING_LIST_QUEUE=waitlist
+```
+
+Whatever you set here, the worker has to be told the same two things — `php artisan queue:work redis --queue=waitlist`.
+Setting one without the other is the failure worth knowing about: the job is dispatched onto a queue nothing is
+reading, so the sign up succeeds, the entry verifies, no exception is raised and nothing is logged, and the entry
+simply never reaches the provider. Putting the sync on its own queue is still worth doing — a provider having a slow
+day should not sit in front of your mail — but an unread queue looks exactly like a broken integration.
+
 #### Drivers
 
 | Driver         | The list id is                                            | Notes                                                                          |
@@ -476,8 +492,45 @@ the provider's API.
 | `mailchimp`    | an audience id                                            | Contacts are upserted, so an existing unsubscribe is never overridden          |
 | `kit`          | a form id, or a tag id with `list_type` set to `tag`      | Kit unsubscribes are account-wide; double opt-in follows the form's setting    |
 | `audienceful`  | a publication id, or a tag name with `list_type` set to `tag` | Unsubscribing withdraws consent for that publication — or, for a tag, workspace wide |
+| `constant_contact` | a contact list id (a UUID)                            | OAuth2 — see below. Unsubscribing leaves the one list, not the account          |
 | `log`          | anything                                                  | Writes what would have been sent to the log — handy for local work             |
 | `array`        | anything                                                  | In-memory, used by `MailingList::fake()` in tests                              |
+
+##### Constant Contact needs authorising by hand
+
+Constant Contact's V3 API is OAuth2 and **none of its flows work without a
+person at a browser** — there is no client-credentials flow, so an application
+cannot get its first token on its own. Authorise the account once, then give the
+package the refresh token it hands back:
+
+```dotenv
+CONSTANT_CONTACT_CLIENT_ID=...
+CONSTANT_CONTACT_CLIENT_SECRET=...
+CONSTANT_CONTACT_REFRESH_TOKEN=...
+CONSTANT_CONTACT_LIST_ID=...
+```
+
+`CONSTANT_CONTACT_REFRESH_TOKEN` is a **seed, not a setting**. Every exchange
+invalidates the token used and issues a replacement, so the value in your
+environment is spent the first time the driver runs. From then on the stored
+rotation is what keeps the connection alive.
+
+By default those rotations are kept in the cache, which asks nothing of your
+application — but a cache flush loses the connection and somebody has to
+authorise the account again. Anything that cannot tolerate that should store
+them itself:
+
+```php
+'constant_contact' => [
+    // ...
+    'refresh_token_store' => new YourTokenTable(),  // implements RefreshTokenStore
+],
+```
+
+Two more differences worth knowing. Access tokens last 24 hours and are cached
+for slightly less, so the driver refreshes roughly once a day on its own. And a
+refresh token expires after 180 days **if it is never used** — a list that goes
+quiet for six months goes dead, and only a human can revive it.
 
 #### Backfilling existing entries
 
@@ -604,15 +657,15 @@ return [
     // Mailing list integration
     'mailing_list' => [
         'enabled' => false,  // Turn syncing on
-        'default' => 'log',  // mailchimp, kit, audienceful, log, array — or your own
+        'default' => 'log',  // mailchimp, kit, audienceful, constant_contact, log, array — or your own
         'auto_subscribe' => true,  // Subscribe entries automatically
         'double_optin' => false,  // Mailchimp and Audienceful; Kit follows the form's setting
         'tags' => [],  // Applied to every subscriber the package creates
         'attributes' => null,  // Closure mapping an entry to provider fields
         'queue' => [
             'enabled' => true,  // Sync in a queued job
-            'connection' => null,
-            'queue' => null,
+            'connection' => null,  // Null uses the app default — make sure a worker reads it
+            'queue' => null,       // Null uses the app default — make sure a worker reads it
         ],
         'timeout' => 10,  // HTTP timeout in seconds
         'retries' => 2,  // Retries per request
@@ -631,6 +684,13 @@ return [
                 'key' => env('AUDIENCEFUL_API_KEY'),
                 'list_type' => env('AUDIENCEFUL_LIST_TYPE', 'publication'),  // publication or tag
                 'list_id' => env('AUDIENCEFUL_PUBLICATION_ID'),
+            ],
+            'constant_contact' => [
+                'client_id' => env('CONSTANT_CONTACT_CLIENT_ID'),
+                'client_secret' => env('CONSTANT_CONTACT_CLIENT_SECRET'),
+                'refresh_token' => env('CONSTANT_CONTACT_REFRESH_TOKEN'),  // A seed; rotations are stored
+                'refresh_token_store' => null,  // A RefreshTokenStore, or the cache when null
+                'list_id' => env('CONSTANT_CONTACT_LIST_ID'),  // A contact list id
             ],
         ],
     ],

--- a/config/waitlist.php
+++ b/config/waitlist.php
@@ -178,6 +178,23 @@ return [
                 'list_id' => env('AUDIENCEFUL_PUBLICATION_ID'),
             ],
 
+            /*
+             * OAuth2 only — there is no API key, and no flow that works
+             * without a person at a browser. `refresh_token` is the one
+             * somebody authorised by hand; it is a seed, not a setting, and is
+             * spent the first time it is exchanged. Set `refresh_token_store`
+             * to a RefreshTokenStore to keep the rotations somewhere sturdier
+             * than the cache.
+             */
+            'constant_contact' => [
+                'client_id' => env('CONSTANT_CONTACT_CLIENT_ID'),
+                'client_secret' => env('CONSTANT_CONTACT_CLIENT_SECRET'),
+                'refresh_token' => env('CONSTANT_CONTACT_REFRESH_TOKEN'),
+                'refresh_token_store' => null,
+                // A contact list id (a UUID), not a form or a tag.
+                'list_id' => env('CONSTANT_CONTACT_LIST_ID'),
+            ],
+
             'log' => [
                 'channel' => env('WAITLIST_MAILING_LIST_LOG_CHANNEL'),
                 'list_id' => 'log',

--- a/src/MailingList/ConstantContact/AccessToken.php
+++ b/src/MailingList/ConstantContact/AccessToken.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\ConstantContact;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+
+/**
+ * Keeps a usable Constant Contact access token in hand.
+ *
+ * Constant Contact is the only provider here that cannot be driven by a static
+ * key. Its V3 API is OAuth2 and every one of its flows — authorization code,
+ * PKCE, device, implicit — needs a person at a browser; there is no
+ * client-credentials flow. So an application cannot obtain its first token on
+ * its own, and this class does not try. It is given a refresh token that
+ * somebody authorised once, and its job is to keep trading that in.
+ *
+ * Two lifetimes matter:
+ *
+ * - An access token lasts 24 hours. It is cached for slightly less, so a token
+ *   is never presented in the seconds around its expiry.
+ * - A refresh token lasts 180 days *if never used*, and each exchange issues a
+ *   new one. Using it therefore keeps the connection alive, and losing the
+ *   replacement ends it — which is why the new refresh token is written back to
+ *   the store before the access token is returned.
+ *
+ * The store is the cache by default, which makes this work with no migration.
+ * A cache flush loses the refresh token and the connection has to be authorised
+ * again by hand, so an application that cannot tolerate that should hand in a
+ * store backed by its own table.
+ */
+final class AccessToken
+{
+    private const string TOKEN_URL = 'https://authz.constantcontact.com/oauth2/default/v1/token';
+
+    /** A margin against clock drift and time spent in flight. */
+    private const int EXPIRY_MARGIN_SECONDS = 300;
+
+    public function __construct(
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+        private readonly RefreshTokenStore $store,
+        private readonly int $timeout = 10,
+    ) {}
+
+    public function value(): string
+    {
+        $cached = Cache::get($this->cacheKey());
+
+        if (is_string($cached) && $cached !== '') {
+            return $cached;
+        }
+
+        return $this->refresh();
+    }
+
+    /**
+     * Trade the stored refresh token for a new pair.
+     */
+    public function refresh(): string
+    {
+        $refreshToken = $this->store->get();
+
+        if ($refreshToken === null || $refreshToken === '') {
+            throw MailingListException::missingCredentials('constant_contact', 'refresh_token');
+        }
+
+        $response = Http::asForm()
+            ->withBasicAuth($this->clientId, $this->clientSecret)
+            ->timeout($this->timeout)
+            ->acceptJson()
+            ->post(self::TOKEN_URL, [
+                'grant_type' => 'refresh_token',
+                'refresh_token' => $refreshToken,
+            ]);
+
+        if ($response->failed()) {
+            /*
+             * Worth saying plainly, because the way out is not a retry. A
+             * refused refresh token means the connection is over until somebody
+             * authorises the account again in a browser.
+             */
+            throw MailingListException::requestFailed(
+                'constant_contact',
+                'The refresh token was refused, so the account has to be authorised again: '.$response->body(),
+                $response->status(),
+            );
+        }
+
+        $accessToken = (string) $response->json('access_token', '');
+
+        if ($accessToken === '') {
+            throw MailingListException::requestFailed(
+                'constant_contact',
+                'The token response carried no access_token: '.$response->body(),
+                $response->status(),
+            );
+        }
+
+        // Before the access token is handed out: if this write is lost, so is
+        // the connection.
+        $rotated = $response->json('refresh_token');
+
+        if (is_string($rotated) && $rotated !== '') {
+            $this->store->put($rotated);
+        }
+
+        $lifetime = (int) $response->json('expires_in', 86400);
+
+        Cache::put(
+            $this->cacheKey(),
+            $accessToken,
+            max(60, $lifetime - self::EXPIRY_MARGIN_SECONDS),
+        );
+
+        return $accessToken;
+    }
+
+    /**
+     * Drop the cached access token, so the next call fetches a fresh one.
+     */
+    public function forget(): void
+    {
+        Cache::forget($this->cacheKey());
+    }
+
+    /**
+     * Keyed by client id so two accounts in one application cannot collide.
+     */
+    private function cacheKey(): string
+    {
+        return 'waitlist.constant_contact.access_token.'.sha1($this->clientId);
+    }
+}

--- a/src/MailingList/ConstantContact/CacheRefreshTokenStore.php
+++ b/src/MailingList/ConstantContact/CacheRefreshTokenStore.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\ConstantContact;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * The default store: the application cache, seeded from config.
+ *
+ * Configuration supplies the token somebody authorised by hand, and it is used
+ * only until the first exchange writes a replacement — from then on the cached
+ * one wins, because the configured value is already spent.
+ *
+ * This asks nothing of the host application, which is the point. It also means
+ * a cache flush loses the connection, so anything that cannot be re-authorised
+ * on short notice should pass a store of its own.
+ */
+final readonly class CacheRefreshTokenStore implements RefreshTokenStore
+{
+    private const string KEY = 'waitlist.constant_contact.refresh_token';
+
+    public function __construct(private ?string $seed = null) {}
+
+    public function get(): ?string
+    {
+        $stored = Cache::get(self::KEY);
+
+        if (is_string($stored) && $stored !== '') {
+            return $stored;
+        }
+
+        return $this->seed !== '' ? $this->seed : null;
+    }
+
+    public function put(string $refreshToken): void
+    {
+        // Forever: it is the only copy once the configured seed is spent.
+        Cache::forever(self::KEY, $refreshToken);
+    }
+}

--- a/src/MailingList/ConstantContact/RefreshTokenStore.php
+++ b/src/MailingList/ConstantContact/RefreshTokenStore.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\ConstantContact;
+
+/**
+ * Where the Constant Contact refresh token lives between requests.
+ *
+ * It has to be writable, not just readable: every exchange issues a new refresh
+ * token and invalidates the one used, so a store that cannot be written — an
+ * environment variable, say — works exactly once and then locks the account
+ * out until it is authorised again by hand.
+ */
+interface RefreshTokenStore
+{
+    public function get(): ?string;
+
+    public function put(string $refreshToken): void;
+}

--- a/src/MailingList/Drivers/ConstantContactDriver.php
+++ b/src/MailingList/Drivers/ConstantContactDriver.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OffloadProject\Waitlist\MailingList\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use OffloadProject\Waitlist\Contracts\MailingListDriver;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\Concerns\ResolvesEntryAttributes;
+use OffloadProject\Waitlist\MailingList\ConstantContact\AccessToken;
+use OffloadProject\Waitlist\MailingList\Subscriber;
+use OffloadProject\Waitlist\Models\WaitlistEntry;
+
+/**
+ * Constant Contact API V3.
+ *
+ * The list id is a contact list id (a UUID). Unlike Kit, which segments one
+ * pool of subscribers by form or tag, Constant Contact has real lists and a
+ * contact belongs to them directly.
+ *
+ * Two things about this provider shape the code here:
+ *
+ * - It is OAuth2 with no client-credentials flow, so there is no static key.
+ *   `AccessToken` keeps a token in hand; see its notes on what that costs.
+ * - Custom fields are addressed by id, not by name. Attributes are therefore
+ *   resolved against the account's fields and anything unrecognised is dropped
+ *   rather than sent, because the API rejects the whole contact over one
+ *   unknown id.
+ *
+ * @see https://developer.constantcontact.com/api_guide/v3_technical_overview.html
+ */
+final class ConstantContactDriver implements MailingListDriver
+{
+    use ResolvesEntryAttributes;
+
+    private const string BASE_URL = 'https://api.cc.email/v3';
+
+    /** @var array<string, string>|null Field name (lowercased) to field id. */
+    private ?array $customFieldIds = null;
+
+    /** @var array<string, string> Tag name to tag id. */
+    private array $tagIds = [];
+
+    public function __construct(
+        private readonly AccessToken $token,
+        private readonly int $timeout = 10,
+        private readonly int $retries = 2,
+    ) {}
+
+    public function name(): string
+    {
+        return 'constant_contact';
+    }
+
+    public function subscribe(WaitlistEntry $entry, string $listId, array $options = []): Subscriber
+    {
+        /*
+         * `sign_up_form` rather than `POST /contacts`: it upserts on the email
+         * address, and it records the contact's permission as having come from
+         * a sign-up form, which is what actually happened. Creating the contact
+         * outright would assert a consent basis the waitlist cannot vouch for.
+         */
+        $response = $this->request()->post('/contacts/sign_up_form', array_filter([
+            'email_address' => $entry->email,
+            'first_name' => $this->firstName($entry),
+            'list_memberships' => [$listId],
+            'custom_fields' => $this->customFields($entry, $options),
+        ]));
+
+        $this->throwUnlessSuccessful($response);
+
+        $subscriber = new Subscriber(
+            id: (string) $response->json('contact_id', ''),
+            email: $entry->email,
+            status: (string) $response->json('action', ''),
+            raw: $response->json() ?? [],
+        );
+
+        $tags = $this->tags($options);
+
+        if ($tags !== []) {
+            $this->tag($entry, $listId, $tags);
+        }
+
+        return $subscriber;
+    }
+
+    /**
+     * Removes the contact from this list rather than deleting them.
+     *
+     * Constant Contact has no per-list unsubscribe: setting the memberships to
+     * everything but this list is how a contact leaves one list while staying
+     * on the others. Deleting them would take the rest with it.
+     */
+    public function unsubscribe(WaitlistEntry $entry, string $listId): void
+    {
+        $contact = $this->contact($entry->email);
+
+        if ($contact === null) {
+            return;
+        }
+
+        $contactId = (string) ($contact['contact_id'] ?? '');
+
+        /** @var list<string> $memberships */
+        $memberships = array_values(array_filter(
+            $contact['list_memberships'] ?? [],
+            static fn (string $id): bool => $id !== $listId,
+        ));
+
+        $this->throwUnlessSuccessful(
+            $this->request()->put("/contacts/{$contactId}", [
+                'email_address' => ['address' => $entry->email],
+                'list_memberships' => $memberships,
+                // Required by the endpoint, and this is the only source we can
+                // honestly claim for a waitlist sign-up.
+                'update_source' => 'Contact',
+            ])
+        );
+    }
+
+    public function tag(WaitlistEntry $entry, string $listId, array $tags): void
+    {
+        $contact = $this->contact($entry->email);
+
+        if ($contact === null) {
+            return;
+        }
+
+        $contactId = (string) ($contact['contact_id'] ?? '');
+
+        foreach ($tags as $tag) {
+            $this->throwUnlessSuccessful(
+                $this->request()->post('/activities/contacts_taggings_add', [
+                    'source' => ['contact_ids' => [$contactId]],
+                    'tag_id' => $this->tagId($tag),
+                ])
+            );
+        }
+    }
+
+    public function find(string $email, string $listId): ?Subscriber
+    {
+        $contact = $this->contact($email);
+
+        if ($contact === null) {
+            return null;
+        }
+
+        return new Subscriber(
+            id: (string) ($contact['contact_id'] ?? ''),
+            email: $email,
+            status: isset($contact['update_source']) ? (string) $contact['update_source'] : null,
+            raw: $contact,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function contact(string $email): ?array
+    {
+        $response = $this->request()->get('/contacts', [
+            'email' => $email,
+            'include' => 'list_memberships,custom_fields,taggings',
+        ]);
+
+        $this->throwUnlessSuccessful($response);
+
+        /** @var array<int, array<string, mixed>> $contacts */
+        $contacts = $response->json('contacts', []);
+
+        return $contacts[0] ?? null;
+    }
+
+    /**
+     * Attributes as Constant Contact wants them: a list of id/value pairs.
+     *
+     * An attribute with no matching field on the account is skipped. The
+     * alternative is a rejected contact — the API fails the whole call over one
+     * unknown id — and losing the sign-up is worse than losing the annotation.
+     *
+     * @param  array{tags?: array<array-key, string>, double_optin?: bool, attributes?: array<string, mixed>}  $options
+     * @return list<array{custom_field_id: string, value: string}>
+     */
+    private function customFields(WaitlistEntry $entry, array $options): array
+    {
+        $attributes = $this->attributes($entry, $options);
+
+        if ($attributes === []) {
+            return [];
+        }
+
+        $fields = [];
+
+        foreach ($attributes as $name => $value) {
+            $id = $this->customFieldId((string) $name);
+
+            if ($id !== null) {
+                $fields[] = ['custom_field_id' => $id, 'value' => (string) $value];
+            }
+        }
+
+        return $fields;
+    }
+
+    private function customFieldId(string $name): ?string
+    {
+        if ($this->customFieldIds === null) {
+            $response = $this->request()->get('/contact_custom_fields', ['limit' => 100]);
+
+            $this->throwUnlessSuccessful($response);
+
+            $this->customFieldIds = [];
+
+            /** @var array<int, array{custom_field_id?: string, label?: string, name?: string}> $fields */
+            $fields = $response->json('custom_fields', []);
+
+            foreach ($fields as $field) {
+                $id = $field['custom_field_id'] ?? null;
+
+                // Matched on either, because the label is what a person sees in
+                // the UI and the name is what the API answers with.
+                foreach ([$field['label'] ?? null, $field['name'] ?? null] as $key) {
+                    if (is_string($key) && is_string($id)) {
+                        $this->customFieldIds[mb_strtolower($key)] = $id;
+                    }
+                }
+            }
+        }
+
+        return $this->customFieldIds[mb_strtolower($name)] ?? null;
+    }
+
+    /**
+     * Resolve a tag name to its id, creating the tag when it does not exist.
+     */
+    private function tagId(string $tag): string
+    {
+        if (isset($this->tagIds[$tag])) {
+            return $this->tagIds[$tag];
+        }
+
+        $response = $this->request()->get('/contact_tags', ['limit' => 500]);
+
+        $this->throwUnlessSuccessful($response);
+
+        /** @var array<int, array{tag_id?: string, name?: string}> $existing */
+        $existing = $response->json('tags', []);
+
+        foreach ($existing as $candidate) {
+            if (isset($candidate['name'], $candidate['tag_id']) && $candidate['name'] === $tag) {
+                return $this->tagIds[$tag] = (string) $candidate['tag_id'];
+            }
+        }
+
+        $created = $this->request()->post('/contact_tags', ['name' => $tag]);
+
+        $this->throwUnlessSuccessful($created);
+
+        return $this->tagIds[$tag] = (string) $created->json('tag_id');
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl(self::BASE_URL)
+            ->withToken($this->token->value())
+            ->timeout($this->timeout)
+            ->retry(max(1, $this->retries), 250, throw: false)
+            ->acceptJson();
+    }
+
+    private function throwUnlessSuccessful(Response $response): void
+    {
+        if ($response->successful()) {
+            return;
+        }
+
+        /*
+         * Errors arrive as a list of objects rather than strings, so the
+         * message is assembled rather than imploded — otherwise every failure
+         * reports "Array to string conversion" and says nothing.
+         */
+        $errors = $response->json();
+
+        $message = is_array($errors)
+            ? implode(' ', array_map(
+                static fn (mixed $error): string => is_array($error)
+                    ? (string) ($error['error_message'] ?? json_encode($error))
+                    : (string) $error,
+                $errors,
+            ))
+            : $response->body();
+
+        throw MailingListException::requestFailed('constant_contact', $message, $response->status());
+    }
+}

--- a/src/MailingList/MailingListManager.php
+++ b/src/MailingList/MailingListManager.php
@@ -8,8 +8,12 @@ use Closure;
 use Illuminate\Support\Facades\Config;
 use OffloadProject\Waitlist\Contracts\MailingListDriver;
 use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\MailingList\ConstantContact\AccessToken;
+use OffloadProject\Waitlist\MailingList\ConstantContact\CacheRefreshTokenStore;
+use OffloadProject\Waitlist\MailingList\ConstantContact\RefreshTokenStore;
 use OffloadProject\Waitlist\MailingList\Drivers\ArrayDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\AudiencefulDriver;
+use OffloadProject\Waitlist\MailingList\Drivers\ConstantContactDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\KitDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\LogDriver;
 use OffloadProject\Waitlist\MailingList\Drivers\MailchimpDriver;
@@ -147,6 +151,7 @@ final class MailingListManager
             'mailchimp' => $this->createMailchimpDriver($config),
             'kit' => $this->createKitDriver($config),
             'audienceful' => $this->createAudiencefulDriver($config),
+            'constant_contact' => $this->createConstantContactDriver($config),
             'log' => new LogDriver(isset($config['channel']) ? (string) $config['channel'] : null),
             'array' => new ArrayDriver(),
             default => throw MailingListException::driverNotSupported($name),
@@ -199,6 +204,38 @@ final class MailingListManager
         return new AudiencefulDriver(
             key: (string) $config['key'],
             listType: (string) ($config['list_type'] ?? 'publication'),
+            timeout: $this->timeout($config),
+            retries: $this->retries($config),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function createConstantContactDriver(array $config): ConstantContactDriver
+    {
+        foreach (['client_id', 'client_secret'] as $required) {
+            if (blank($config[$required] ?? null)) {
+                throw MailingListException::missingCredentials('constant_contact', $required);
+            }
+        }
+
+        /*
+         * The store is injectable because the refresh token rotates on every
+         * exchange: an application that cannot afford to lose it to a cache
+         * flush passes its own, backed by a table.
+         */
+        $store = $config['refresh_token_store'] ?? null;
+
+        return new ConstantContactDriver(
+            token: new AccessToken(
+                clientId: (string) $config['client_id'],
+                clientSecret: (string) $config['client_secret'],
+                store: $store instanceof RefreshTokenStore
+                    ? $store
+                    : new CacheRefreshTokenStore(filled($config['refresh_token'] ?? null) ? (string) $config['refresh_token'] : null),
+                timeout: $this->timeout($config),
+            ),
             timeout: $this->timeout($config),
             retries: $this->retries($config),
         );

--- a/tests/Feature/ConstantContactTest.php
+++ b/tests/Feature/ConstantContactTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use OffloadProject\Waitlist\Exceptions\MailingListException;
+use OffloadProject\Waitlist\Facades\MailingList;
+use OffloadProject\Waitlist\Facades\Waitlist;
+
+const CC_LIST = 'd13d60d0-f256-11e8-b47d-fa163e56c9b0';
+
+beforeEach(function (): void {
+    config([
+        'waitlist.mailing_list.enabled' => true,
+        'waitlist.mailing_list.default' => 'constant_contact',
+        'waitlist.mailing_list.queue.enabled' => false,
+        'waitlist.mailing_list.drivers.constant_contact.client_id' => 'client-id',
+        'waitlist.mailing_list.drivers.constant_contact.client_secret' => 'client-secret',
+        'waitlist.mailing_list.drivers.constant_contact.refresh_token' => 'seed-refresh-token',
+        'waitlist.mailing_list.drivers.constant_contact.list_id' => CC_LIST,
+    ]);
+});
+
+/** The token exchange, which every other call depends on. */
+function ccToken(array $overrides = []): array
+{
+    return array_merge([
+        'access_token' => 'access-1',
+        'refresh_token' => 'refresh-2',
+        'expires_in' => 86400,
+    ], $overrides);
+}
+
+test('it signs a new entry up and puts them on the list', function () {
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken()),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'contact-1', 'action' => 'created'], 201),
+    ]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request): bool {
+        if (! str_contains($request->url(), 'sign_up_form')) {
+            return false;
+        }
+
+        return $request['email_address'] === 'john@example.com'
+            && $request['first_name'] === 'John'
+            && $request['list_memberships'] === [CC_LIST];
+    });
+
+    expect($entry->fresh()->mailing_list_driver)->toBe('constant_contact')
+        ->and($entry->fresh()->mailing_list_subscriber_id)->toBe('contact-1');
+});
+
+/*
+ * The refresh token is single use: each exchange invalidates the one sent and
+ * issues a replacement. Losing the replacement ends the connection, so it is
+ * written back before the access token is ever used.
+ */
+test('it stores the rotated refresh token', function () {
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken(['refresh_token' => 'refresh-rotated'])),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'c1', 'action' => 'created'], 201),
+    ]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    expect(Cache::get('waitlist.constant_contact.refresh_token'))->toBe('refresh-rotated');
+});
+
+test('it reuses a cached access token rather than exchanging every time', function () {
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken()),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'c1', 'action' => 'created'], 201),
+    ]);
+
+    Waitlist::add('One', 'one@example.com');
+    MailingList::forget();
+    Waitlist::add('Two', 'two@example.com');
+
+    $exchanges = collect(Http::recorded())
+        ->filter(fn (array $pair): bool => str_contains($pair[0]->url(), 'oauth2'))
+        ->count();
+
+    expect($exchanges)->toBe(1);
+});
+
+/*
+ * A refused refresh token is not a transient failure — nobody can fix it
+ * without authorising the account again in a browser — so the message has to
+ * say that rather than reading as a network blip.
+ */
+test('it says so plainly when the refresh token is refused', function () {
+    Http::fake([
+        '*/oauth2/*' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    expect(fn () => Waitlist::add('John Doe', 'john@example.com'))
+        ->toThrow(MailingListException::class, 'authorised again');
+});
+
+test('it needs a client id and secret', function () {
+    config(['waitlist.mailing_list.drivers.constant_contact.client_id' => null]);
+
+    expect(fn () => MailingList::driver('constant_contact'))
+        ->toThrow(MailingListException::class, 'client_id');
+});
+
+/*
+ * Constant Contact addresses custom fields by id and rejects the whole contact
+ * over one it does not know, so an unmatched attribute is dropped instead.
+ */
+test('it maps attributes onto custom field ids and drops the rest', function () {
+    config(['waitlist.mailing_list.attributes' => fn () => ['Persona' => 'System Hopper', 'Nonesuch' => 'x']]);
+
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken()),
+        '*/contact_custom_fields*' => Http::response(['custom_fields' => [
+            ['custom_field_id' => 'field-1', 'label' => 'Persona', 'name' => 'persona'],
+        ]]),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'c1', 'action' => 'created'], 201),
+    ]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(function ($request): bool {
+        if (! str_contains($request->url(), 'sign_up_form')) {
+            return false;
+        }
+
+        return $request['custom_fields'] === [['custom_field_id' => 'field-1', 'value' => 'System Hopper']];
+    });
+});
+
+test('it creates a tag it has not seen and applies it', function () {
+    config(['waitlist.mailing_list.tags' => ['yhy-waitlist']]);
+
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken()),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'contact-1', 'action' => 'created'], 201),
+        '*/contacts?*' => Http::response(['contacts' => [['contact_id' => 'contact-1', 'list_memberships' => [CC_LIST]]]]),
+        '*/contact_tags?*' => Http::response(['tags' => []]),
+        '*/contact_tags' => Http::response(['tag_id' => 'tag-1'], 201),
+        '*/activities/contacts_taggings_add' => Http::response(['activity_id' => 'a1'], 201),
+    ]);
+
+    Waitlist::add('John Doe', 'john@example.com');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'contacts_taggings_add')
+        && $request['tag_id'] === 'tag-1'
+        && $request['source']['contact_ids'] === ['contact-1']);
+});
+
+/*
+ * Leaving one list must not take the others with it, so the contact is updated
+ * with the remaining memberships rather than deleted.
+ */
+test('unsubscribing removes only this list', function () {
+    Http::fake([
+        '*/oauth2/*' => Http::response(ccToken()),
+        '*/contacts/sign_up_form' => Http::response(['contact_id' => 'contact-1', 'action' => 'created'], 201),
+        '*/contacts?*' => Http::response(['contacts' => [[
+            'contact_id' => 'contact-1',
+            'list_memberships' => [CC_LIST, 'other-list'],
+        ]]]),
+        '*/contacts/contact-1' => Http::response(['contact_id' => 'contact-1'], 200),
+    ]);
+
+    $entry = Waitlist::add('John Doe', 'john@example.com');
+
+    Waitlist::unsubscribeFromMailingList($entry);
+
+    Http::assertSent(fn ($request): bool => $request->method() === 'PUT'
+        && str_contains($request->url(), '/contacts/contact-1')
+        && $request['list_memberships'] === ['other-list']);
+});


### PR DESCRIPTION
# Description

 Adds Constant Contact as a fourth mailing list driver, alongside Mailchimp, Kit and Audienceful.

  ## Why this driver is shaped differently

  Every other driver here takes an API key from config and is done. Constant Contact cannot: its V3 API is OAuth2, and **none of its flows work without a person at a 
  browser**. There is no client-credentials flow, so an application cannot obtain its first token on its own.

  That constraint drives most of what is new here:

  - **`AccessToken`** keeps a usable token in hand. Access tokens last 24 hours and are cached for slightly less, so the driver refreshes about once a day on its own.
  - **A refresh token is single use.** Each exchange invalidates the one sent and issues a replacement, so it cannot live in an environment variable — that works exactly
  once and then locks the account out. `CONSTANT_CONTACT_REFRESH_TOKEN` is therefore a *seed*, spent on first use, and the rotation is written back to a store before
  the access token is returned. Losing that write ends the connection.
  - **`RefreshTokenStore`** is an interface with a cache-backed default, so the package asks nothing of the host application. A cache flush loses the connection and
  somebody has to authorise the account again, so anything that cannot tolerate that passes its own store.

  A refused refresh token is reported as such rather than as a generic request failure, because retrying will never fix it — that state needs a human in a browser.

  ## Where Constant Contact differs from the others                                                                                                                 

  - **Real lists.** The list id is a contact list UUID, not a form or tag id. Kit segments one pool of subscribers; Constant Contact has actual lists and a contact
  belongs to them.                                                                                                                                                  
  - **Sign-up form endpoint.** `POST /contacts/sign_up_form` upserts on email address *and* records the contact's permission as having come from a sign-up form — which
  is what actually happened. `POST /contacts` would assert a consent basis a waitlist cannot vouch for.
  - **Custom fields are addressed by id, not name.** Attributes are resolved against the account's fields and anything unmatched is dropped rather than sent, because the
  API rejects the whole contact over a single unknown id. Losing an annotation beats losing the sign-up.
  - **Unsubscribing rewrites memberships.** There is no per-list unsubscribe. The contact is updated with every list *except* this one, so leaving one list does not take
  the others with it, and the contact is not deleted.
  - **Errors arrive as objects, not strings.** They are assembled into a message rather than imploded; otherwise every failure reports "Array to string conversion" and
  says nothing.

  ## What this does not do
  
  Constant Contact cannot enrol a contact into an automation through the API — the only route is adding them to a list that a pre-built list-join series is attached to.
  It also has no Liquid, so conditional email content of the kind Kit supports has no equivalent. Anyone moving between the two drivers should not expect parity.

  ## Tests

  Eight covering the token exchange, rotation being persisted, an access token being reused rather than re-exchanged, a refused refresh token, missing credentials,
  custom field mapping with an unmatched field dropped, tag creation and application, and unsubscribing leaving other lists intact. All HTTP is faked.